### PR TITLE
Add inventory schema: Location, Item, CheckoutLog models

### DIFF
--- a/prisma/migrations/20260425002023_inventory_models/migration.sql
+++ b/prisma/migrations/20260425002023_inventory_models/migration.sql
@@ -1,0 +1,88 @@
+-- CreateTable
+CREATE TABLE "location" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "address" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "item" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "condition" TEXT NOT NULL DEFAULT 'good',
+    "status" TEXT NOT NULL DEFAULT 'available',
+    "homeLocationId" TEXT NOT NULL,
+    "currentLocationId" TEXT NOT NULL,
+    "qrCodeUrl" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "item_homeLocationId_fkey" FOREIGN KEY ("homeLocationId") REFERENCES "location" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "item_currentLocationId_fkey" FOREIGN KEY ("currentLocationId") REFERENCES "location" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "checkout_log" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "itemId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "checkedOutBy" TEXT NOT NULL,
+    "checkedOutFromLocationId" TEXT NOT NULL,
+    "checkedOutAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "checkedInBy" TEXT,
+    "checkedInAtLocationId" TEXT,
+    "checkedInAt" DATETIME,
+    "conditionOnReturn" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "checkout_log_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "item" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "checkout_log_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "checkout_log_checkedOutBy_fkey" FOREIGN KEY ("checkedOutBy") REFERENCES "user" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "checkout_log_checkedOutFromLocationId_fkey" FOREIGN KEY ("checkedOutFromLocationId") REFERENCES "location" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "checkout_log_checkedInBy_fkey" FOREIGN KEY ("checkedInBy") REFERENCES "user" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "checkout_log_checkedInAtLocationId_fkey" FOREIGN KEY ("checkedInAtLocationId") REFERENCES "location" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_user" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "legalFirstName" TEXT,
+    "legalLastName" TEXT,
+    "preferredFirstName" TEXT,
+    "preferredLastName" TEXT,
+    "role" TEXT NOT NULL DEFAULT 'employee',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_user" ("createdAt", "email", "emailVerified", "id", "image", "name", "updatedAt") SELECT "createdAt", "email", "emailVerified", "id", "image", "name", "updatedAt" FROM "user";
+DROP TABLE "user";
+ALTER TABLE "new_user" RENAME TO "user";
+CREATE UNIQUE INDEX "user_email_key" ON "user"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "item_homeLocationId_idx" ON "item"("homeLocationId");
+
+-- CreateIndex
+CREATE INDEX "item_currentLocationId_idx" ON "item"("currentLocationId");
+
+-- CreateIndex
+CREATE INDEX "item_status_idx" ON "item"("status");
+
+-- CreateIndex
+CREATE INDEX "checkout_log_itemId_idx" ON "checkout_log"("itemId");
+
+-- CreateIndex
+CREATE INDEX "checkout_log_userId_idx" ON "checkout_log"("userId");
+
+-- CreateIndex
+CREATE INDEX "checkout_log_checkedInAt_idx" ON "checkout_log"("checkedInAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,15 +8,25 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(uuid())
-  name          String
-  email         String
-  emailVerified Boolean   @default(false)
-  image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  sessions      Session[]
-  accounts      Account[]
+  id                String    @id @default(uuid())
+  name              String
+  email             String
+  emailVerified     Boolean   @default(false)
+  image             String?
+  legalFirstName    String?
+  legalLastName     String?
+  preferredFirstName String?
+  preferredLastName  String?
+  role              String    @default("employee")
+  status            String    @default("active")
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  sessions          Session[]
+  accounts          Account[]
+
+  itemsHeld         CheckoutLog[] @relation("ItemHolder")
+  checkoutsPerformed CheckoutLog[] @relation("CheckoutPerformer")
+  checkinsPerformed  CheckoutLog[] @relation("CheckinPerformer")
 
   @@unique([email])
   @@map("user")
@@ -68,4 +78,68 @@ model Verification {
 
   @@index([identifier])
   @@map("verification")
+}
+
+model Location {
+  id        String   @id @default(uuid())
+  name      String
+  address   String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  homeItems     Item[]         @relation("HomeLocation")
+  currentItems  Item[]         @relation("CurrentLocation")
+  checkoutsFrom CheckoutLog[]  @relation("CheckedOutFromLocation")
+  checkinsAt    CheckoutLog[]  @relation("CheckedInAtLocation")
+
+  @@map("location")
+}
+
+model Item {
+  id                String   @id @default(uuid())
+  name              String
+  description       String?
+  condition         String   @default("good")
+  status            String   @default("available")
+  homeLocationId    String
+  homeLocation      Location @relation("HomeLocation", fields: [homeLocationId], references: [id])
+  currentLocationId String
+  currentLocation   Location @relation("CurrentLocation", fields: [currentLocationId], references: [id])
+  qrCodeUrl         String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  checkoutLogs CheckoutLog[]
+
+  @@index([homeLocationId])
+  @@index([currentLocationId])
+  @@index([status])
+  @@map("item")
+}
+
+model CheckoutLog {
+  id                       String    @id @default(uuid())
+  itemId                   String
+  item                     Item      @relation(fields: [itemId], references: [id])
+  userId                   String
+  user                     User      @relation("ItemHolder", fields: [userId], references: [id])
+  checkedOutBy             String
+  checkedOutByUser         User      @relation("CheckoutPerformer", fields: [checkedOutBy], references: [id])
+  checkedOutFromLocationId String
+  checkedOutFromLocation   Location  @relation("CheckedOutFromLocation", fields: [checkedOutFromLocationId], references: [id])
+  checkedOutAt             DateTime  @default(now())
+
+  checkedInBy              String?
+  checkedInByUser          User?     @relation("CheckinPerformer", fields: [checkedInBy], references: [id])
+  checkedInAtLocationId    String?
+  checkedInAtLocation      Location? @relation("CheckedInAtLocation", fields: [checkedInAtLocationId], references: [id])
+  checkedInAt              DateTime?
+  conditionOnReturn        String?
+
+  createdAt DateTime @default(now())
+
+  @@index([itemId])
+  @@index([userId])
+  @@index([checkedInAt])
+  @@map("checkout_log")
 }


### PR DESCRIPTION
## Summary
- Extends `User` model with name fields (legal/preferred), role, and status
- Adds `Location` model for physical sites (name, address)
- Adds `Item` model for equipment (condition, status, home/current location)
- Adds `CheckoutLog` model for full audit trail of check-in/check-out activity
- Includes all indexes specified in the data model docs

Closes #1

## Test plan
- [x] `prisma migrate dev` runs cleanly on a fresh database
- [x] `prisma generate` succeeds
- [x] Existing Better Auth models (Session, Account, Verification) unchanged
- [x] All new fields, relations, and indexes present in migration SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)