### PR TITLE
Rewrite seed script for locations and users from roster CSV

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^17.2.3",
     "nodemailer": "^7.0.11",
     "nuxt": "^4.3.1",
+    "papaparse": "^5.5.3",
     "vue": "^3.5.25",
     "vue-router": "^4.6.4",
     "zod": "^4.2.1"
@@ -47,6 +48,7 @@
     "@nuxt/test-utils": "^4.0.2",
     "@playwright/test": "^1.59.1",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/papaparse": "^5.5.2",
     "concurrently": "^9.2.1",
     "eslint": "^10.2.1",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       nuxt:
         specifier: ^4.3.1
         version: 4.3.1(@electric-sql/pglite@0.3.15)(@parcel/watcher@2.5.6)(@types/node@25.2.1)(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.6.2)(mysql2@3.15.3))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      papaparse:
+        specifier: ^5.5.3
+        version: 5.5.3
       vue:
         specifier: ^3.5.25
         version: 3.5.27(typescript@5.9.3)
@@ -56,6 +59,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/papaparse':
+        specifier: ^5.5.2
+        version: 5.5.2
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -3530,6 +3536,12 @@ packages:
     resolution:
       {
         integrity: sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==,
+      }
+
+  '@types/papaparse@5.5.2':
+    resolution:
+      {
+        integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==,
       }
 
   '@types/react@19.2.13':
@@ -7705,6 +7717,12 @@ packages:
     resolution:
       {
         integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==,
+      }
+
+  papaparse@5.5.3:
+    resolution:
+      {
+        integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==,
       }
 
   parse-imports-exports@0.2.4:
@@ -12544,6 +12562,10 @@ snapshots:
     dependencies:
       '@types/node': 25.2.1
 
+  '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 25.2.1
+
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
@@ -15347,6 +15369,8 @@ snapshots:
   package-manager-detector@1.6.0: {}
 
   pako@0.2.9: {}
+
+  papaparse@5.5.3: {}
 
   parse-imports-exports@0.2.4:
     dependencies:

--- a/prisma/migrations/20260425030000_add_location_unique_name/migration.sql
+++ b/prisma/migrations/20260425030000_add_location_unique_name/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "location_name_key" ON "location"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,7 @@ model Location {
   checkoutsFrom CheckoutLog[]  @relation("CheckedOutFromLocation")
   checkinsAt    CheckoutLog[]  @relation("CheckedInAtLocation")
 
+  @@unique([name])
   @@map("location")
 }
 

--- a/prisma/seed.test.ts
+++ b/prisma/seed.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+// Re-implement the pure helper functions from seed.ts for testing
+// (seed.ts runs as a script, so we test the logic directly)
+
+const ADMIN_EMAILS = [
+  'brandy.lindsey@thewarrencenter.org',
+  'isabel.saenz@thewarrencenter.org',
+  'reachtusharwani@gmail.com',
+]
+
+const SUPERVISOR_EMAILS = ['tmw220003@utdallas.edu']
+
+function getRole(email: string): string {
+  const lower = email.toLowerCase()
+  if (ADMIN_EMAILS.includes(lower)) return 'admin'
+  if (SUPERVISOR_EMAILS.includes(lower)) return 'supervisor'
+  return 'employee'
+}
+
+function mapStatus(positionStatus: string): string {
+  const normalized = positionStatus.trim().toLowerCase()
+  if (normalized === 'leave') return 'on_leave'
+  return 'active'
+}
+
+function parseLegalName(legalName: string): { firstName: string; lastName: string } {
+  const commaIndex = legalName.indexOf(',')
+  const lastName = legalName.substring(0, commaIndex).trim()
+  const firstName = legalName.substring(commaIndex + 1).trim()
+  return { firstName, lastName }
+}
+
+function computeDisplayName(
+  legalFirst: string,
+  legalLast: string,
+  preferredFirst: string | null,
+  preferredLast: string | null
+): string {
+  const displayFirst = preferredFirst || legalFirst
+  const displayLast = preferredLast || legalLast
+  return `${displayFirst} ${displayLast}`
+}
+
+describe('seed helpers', () => {
+  describe('getRole', () => {
+    it('returns admin for admin emails', () => {
+      expect(getRole('brandy.lindsey@thewarrencenter.org')).toBe('admin')
+      expect(getRole('isabel.saenz@thewarrencenter.org')).toBe('admin')
+      expect(getRole('reachtusharwani@gmail.com')).toBe('admin')
+    })
+
+    it('returns supervisor for supervisor emails', () => {
+      expect(getRole('tmw220003@utdallas.edu')).toBe('supervisor')
+    })
+
+    it('returns employee for all other emails', () => {
+      expect(getRole('someone@thewarrencenter.org')).toBe('employee')
+      expect(getRole('random@gmail.com')).toBe('employee')
+    })
+  })
+
+  describe('mapStatus', () => {
+    it('maps Active to active', () => {
+      expect(mapStatus('Active')).toBe('active')
+    })
+
+    it('maps Leave to on_leave', () => {
+      expect(mapStatus('Leave')).toBe('on_leave')
+    })
+
+    it('handles whitespace', () => {
+      expect(mapStatus(' Leave ')).toBe('on_leave')
+      expect(mapStatus(' Active ')).toBe('active')
+    })
+  })
+
+  describe('parseLegalName', () => {
+    it('parses simple names', () => {
+      expect(parseLegalName('Abernathy, Christopher')).toEqual({
+        firstName: 'Christopher',
+        lastName: 'Abernathy',
+      })
+    })
+
+    it('handles multi-word last names', () => {
+      expect(parseLegalName('Hernandez Kilpatrick, Hilda')).toEqual({
+        firstName: 'Hilda',
+        lastName: 'Hernandez Kilpatrick',
+      })
+    })
+
+    it('handles multi-word first names', () => {
+      expect(parseLegalName('Camacho, Janina Lizz')).toEqual({
+        firstName: 'Janina Lizz',
+        lastName: 'Camacho',
+      })
+    })
+  })
+
+  describe('computeDisplayName', () => {
+    it('uses legal names when no preferred names', () => {
+      expect(computeDisplayName('Christopher', 'Abernathy', null, null)).toBe(
+        'Christopher Abernathy'
+      )
+    })
+
+    it('uses preferred first name when available', () => {
+      expect(computeDisplayName('Christopher', 'Abernathy', 'Chris', null)).toBe('Chris Abernathy')
+    })
+
+    it('uses preferred last name when available', () => {
+      expect(computeDisplayName('Christopher', 'Abernathy', null, 'Smith')).toBe(
+        'Christopher Smith'
+      )
+    })
+
+    it('uses both preferred names when available', () => {
+      expect(computeDisplayName('Christopher', 'Abernathy', 'Chris', 'Smith')).toBe('Chris Smith')
+    })
+  })
+})

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,24 +1,187 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import Papa from 'papaparse'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { PrismaClient } from './generated/client'
 
 const adapter = new PrismaBetterSqlite3({ url: `${process.env.DATABASE_URL}` })
 const prisma = new PrismaClient({ adapter })
 
+// --- Locations ---
+
+const LOCATIONS = [
+  {
+    name: 'The Warren Center - Central',
+    address: '320 Custer Rd, Richardson, TX 75080',
+  },
+  {
+    name: 'The Warren Center - East',
+    address: '2625 Anita Dr, Garland, TX 75041',
+  },
+  {
+    name: 'The Warren Center - West',
+    address: '400 E Royal Ln Suite 112, Irving, TX 75039',
+  },
+]
+
+// --- Role assignments ---
+
+const ADMIN_EMAILS = [
+  'brandy.lindsey@thewarrencenter.org',
+  'isabel.saenz@thewarrencenter.org',
+  'reachtusharwani@gmail.com',
+]
+
+const SUPERVISOR_EMAILS = ['tmw220003@utdallas.edu']
+
+function getRole(email: string): string {
+  const lower = email.toLowerCase()
+  if (ADMIN_EMAILS.includes(lower)) return 'admin'
+  if (SUPERVISOR_EMAILS.includes(lower)) return 'supervisor'
+  return 'employee'
+}
+
+// --- Status mapping ---
+
+function mapStatus(positionStatus: string): string {
+  const normalized = positionStatus.trim().toLowerCase()
+  if (normalized === 'leave') return 'on_leave'
+  return 'active'
+}
+
+// --- CSV row type ---
+
+interface RosterRow {
+  'Legal Name': string
+  'Preferred or Chosen First Name': string
+  'Preferred or Chosen Last Name': string
+  'Work Contact: Work Email': string
+  'Position Status': string
+  'Job Title Description': string
+}
+
+// --- Non-roster users ---
+
+const EXTRA_USERS = [
+  {
+    legalFirstName: 'Tushar',
+    legalLastName: 'Wani',
+    preferredFirstName: null,
+    preferredLastName: null,
+    email: 'reachtusharwani@gmail.com',
+    role: 'admin' as const,
+    status: 'active' as const,
+  },
+  {
+    legalFirstName: 'Tushar',
+    legalLastName: 'Wani',
+    preferredFirstName: null,
+    preferredLastName: null,
+    email: 'tmw220003@utdallas.edu',
+    role: 'supervisor' as const,
+    status: 'active' as const,
+  },
+]
+
+// --- Main ---
+
 async function main() {
   console.log('Start seeding...')
 
-  // Create a User
-  const user1 = await prisma.user.create({
-    data: {
-      name: "Sample Name", // modify this fit your needs
-      email: "email@example.com"
-    }
+  // 1. Upsert locations
+  for (const loc of LOCATIONS) {
+    await prisma.location.upsert({
+      where: { name: loc.name },
+      update: { address: loc.address },
+      create: { name: loc.name, address: loc.address },
+    })
+  }
+  console.log(`Seeded ${LOCATIONS.length} locations`)
+
+  // 2. Parse roster.csv
+  const csvPath = resolve(import.meta.dirname!, '..', 'roster.csv')
+  const csvContent = readFileSync(csvPath, 'utf-8')
+  const { data: rows } = Papa.parse<RosterRow>(csvContent, {
+    header: true,
+    skipEmptyLines: true,
   })
 
-  console.log({ user1 })
+  // 3. Upsert roster users
+  let rosterCount = 0
+  for (const row of rows) {
+    const legalName = row['Legal Name']?.trim()
+    if (!legalName) continue
+
+    const commaIndex = legalName.indexOf(',')
+    const legalLastName = legalName.substring(0, commaIndex).trim()
+    const legalFirstName = legalName.substring(commaIndex + 1).trim()
+
+    const preferredFirstName = row['Preferred or Chosen First Name']?.trim() || null
+    const preferredLastName = row['Preferred or Chosen Last Name']?.trim() || null
+    const email = row['Work Contact: Work Email']?.trim().toLowerCase()
+    const status = mapStatus(row['Position Status'] || 'Active')
+    const role = getRole(email)
+
+    const displayFirst = preferredFirstName || legalFirstName
+    const displayLast = preferredLastName || legalLastName
+    const name = `${displayFirst} ${displayLast}`
+
+    await prisma.user.upsert({
+      where: { email },
+      update: {
+        name,
+        legalFirstName,
+        legalLastName,
+        preferredFirstName,
+        preferredLastName,
+        role,
+        status,
+      },
+      create: {
+        name,
+        email,
+        legalFirstName,
+        legalLastName,
+        preferredFirstName,
+        preferredLastName,
+        role,
+        status,
+      },
+    })
+    rosterCount++
+  }
+  console.log(`Seeded ${rosterCount} users from roster.csv`)
+
+  // 4. Upsert extra (non-roster) users
+  for (const user of EXTRA_USERS) {
+    const name = `${user.legalFirstName} ${user.legalLastName}`
+    await prisma.user.upsert({
+      where: { email: user.email },
+      update: {
+        name,
+        legalFirstName: user.legalFirstName,
+        legalLastName: user.legalLastName,
+        preferredFirstName: user.preferredFirstName,
+        preferredLastName: user.preferredLastName,
+        role: user.role,
+        status: user.status,
+      },
+      create: {
+        name,
+        email: user.email,
+        legalFirstName: user.legalFirstName,
+        legalLastName: user.legalLastName,
+        preferredFirstName: user.preferredFirstName,
+        preferredLastName: user.preferredLastName,
+        role: user.role,
+        status: user.status,
+      },
+    })
+  }
+  console.log(`Seeded ${EXTRA_USERS.length} extra users`)
+
   console.log('Seeding finished.')
 }
-// You can seed other models in your db as well depending on project needs
 
 main()
   .then(async () => {


### PR DESCRIPTION
## Summary
- Rewrites `prisma/seed.ts` to parse `roster.csv` with PapaParse and seed 3 TWC locations + ~100 users with correct name fields, roles, and statuses
- Adds 2 non-roster users (Tushar admin + Tushar supervisor) with manual entries
- Adds unique constraint on `location.name` for idempotent upserts
- Includes unit tests for name parsing, role assignment, and status mapping helpers

## Verification
- 3 locations seeded with correct names and addresses
- 102 total users (100 roster + 2 extra)
- Brandy Lindsey, Isabel Saenz → `admin`; Tushar UTD → `supervisor`; all others → `employee`
- Amanda Johnston → `on_leave`; all others → `active`
- Seed is idempotent (re-running produces same 102 users)

## Test plan
- [x] `pnpm test` passes (14 tests including seed helper unit tests)
- [x] `pnpm lint` passes
- [x] `npx prisma db seed` runs without errors
- [x] Re-running seed produces identical results (idempotent)
- [x] `pnpm prisma:reset` seeds correctly on a clean database

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)