### PR TITLE
Add location management API routes and admin UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQLite, and Nuxt UI v3. Uses pnpm as the package manager.
+TWC Inventory — an inventory management app for The Warren Center. Built with Nuxt 4, Better Auth (email OTP authentication), Prisma ORM, SQLite, and Nuxt UI v3. Uses pnpm as the package manager.
 
 ## Common Commands
 
@@ -23,20 +23,27 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow) and `/` (dashboard with user list + profile picture upload)
+- **Pages**:
+  - `/auth` — email OTP login flow
+  - `/` — dashboard (user list + profile picture upload)
+  - `/locations` — location list with CRUD modals (admin only)
+  - `/locations/[id]` — location detail with item counts and current items
 
 ### Backend (`server/`)
 
 - **Auth handler**: `server/api/auth/[...all].ts` — catch-all route delegating to Better Auth
-- **Auth config**: `server/utils/auth.ts` — Better Auth setup with Prisma adapter (SQLite) and emailOTP plugin using Nodemailer (Gmail SMTP)
+- **Auth config**: `server/utils/auth.ts` — Better Auth setup with Prisma adapter (SQLite), emailOTP plugin, domain restriction (`isEmailAllowed`)
+- **Auth utility**: `server/utils/require-auth.ts` — `requireAuth(event, roles?)` for session + role checking (returns 401/403)
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
-- **API routes**: `server/api/users/` — user listing, profile image serving, and file upload (multipart form)
+- **API routes**:
+  - `server/api/users/` — user listing, profile image serving, and file upload (multipart form)
+  - `server/api/locations/` — full CRUD with item counts
 
 ### Database (`prisma/`)
 
 - **SQLite** via `better-sqlite3` driver adapter (not the default Prisma SQLite driver)
 - **Prisma client output**: `prisma/generated/` (custom output path)
-- **Schema models**: User, Session, Account, Verification (Better Auth tables)
+- **Schema models**: User, Session, Account, Verification (Better Auth tables), Location, Item, CheckoutLog (inventory tables)
 - **Seed**: `prisma/seed.ts` run via `tsx`
 - **Config**: `prisma.config.ts` at project root
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -20,10 +20,21 @@
         class="sticky top-0 z-50 border-b border-gray-200 bg-white/75 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/75"
       >
         <UContainer class="flex h-16 items-center justify-between">
-          <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
-            <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
-            <span>Nuxt Template</span>
-          </NuxtLink>
+          <div class="flex items-center gap-6">
+            <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
+              <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
+              <span>TWC Inventory</span>
+            </NuxtLink>
+            <nav class="hidden items-center gap-1 md:flex">
+              <NuxtLink
+                to="/locations"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                active-class="text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950"
+              >
+                Locations
+              </NuxtLink>
+            </nav>
+          </div>
 
           <div class="flex items-center gap-2">
             <UButton

--- a/app/pages/locations/[id].vue
+++ b/app/pages/locations/[id].vue
@@ -1,0 +1,273 @@
+<script setup lang="ts">
+  import { z } from 'zod/v4'
+  import { authClient } from '../../utils/auth-client'
+
+  const route = useRoute()
+  const locationId = route.params.id as string
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const isAdmin = computed(() => (session.value?.user as Record<string, unknown>)?.role === 'admin')
+
+  const { data: location, pending, error, refresh } = await useFetch(`/api/locations/${locationId}`)
+
+  const isEditOpen = ref(false)
+  const isDeleteOpen = ref(false)
+  const isSubmitting = ref(false)
+  const isDeleting = ref(false)
+  const deleteError = ref('')
+
+  const toast = useToast()
+
+  const locationSchema = z.object({
+    name: z.string().min(1, 'Name is required').max(200, 'Name must be 200 characters or less'),
+    address: z.string().max(500, 'Address must be 500 characters or less').optional(),
+  })
+
+  type LocationFormState = {
+    name: string
+    address?: string
+  }
+
+  const formState = reactive<LocationFormState>({
+    name: '',
+    address: '',
+  })
+
+  function openEdit() {
+    if (!location.value) return
+    formState.name = location.value.name
+    formState.address = location.value.address ?? ''
+    isEditOpen.value = true
+  }
+
+  function openDelete() {
+    deleteError.value = ''
+    isDeleteOpen.value = true
+  }
+
+  async function submitEdit() {
+    isSubmitting.value = true
+    try {
+      await $fetch(`/api/locations/${locationId}`, {
+        method: 'PUT',
+        body: { name: formState.name, address: formState.address || undefined },
+      })
+      toast.add({ title: 'Location updated', color: 'success' })
+      isEditOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      toast.add({
+        title: fetchErr.data?.statusMessage || 'Failed to update location',
+        color: 'error',
+      })
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  async function confirmDelete() {
+    isDeleting.value = true
+    deleteError.value = ''
+    try {
+      await $fetch(`/api/locations/${locationId}`, {
+        method: 'DELETE',
+      })
+      toast.add({ title: 'Location deleted', color: 'success' })
+      await navigateTo('/locations')
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      deleteError.value = fetchErr.data?.statusMessage || 'Failed to delete location'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+  const conditionColor: Record<string, BadgeColor> = {
+    good: 'success',
+    fair: 'warning',
+    damaged: 'error',
+    retired: 'neutral',
+  }
+
+  const statusColor: Record<string, BadgeColor> = {
+    available: 'success',
+    checked_out: 'warning',
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div v-if="pending" class="space-y-4">
+      <USkeleton class="h-8 w-1/3" />
+      <USkeleton class="h-4 w-1/2" />
+      <USkeleton class="mt-6 h-40 w-full" />
+    </div>
+
+    <div v-else-if="error">
+      <UAlert
+        icon="i-heroicons-exclamation-triangle-20-solid"
+        color="error"
+        variant="subtle"
+        title="Error loading location"
+        :description="error.message"
+      />
+      <UButton class="mt-4" variant="soft" to="/locations" icon="i-heroicons-arrow-left-20-solid">
+        Back to locations
+      </UButton>
+    </div>
+
+    <div v-else-if="location">
+      <div class="mb-6">
+        <NuxtLink
+          to="/locations"
+          class="mb-4 flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <UIcon name="i-heroicons-arrow-left-20-solid" class="h-4 w-4" />
+          Back to locations
+        </NuxtLink>
+
+        <div class="flex flex-col justify-between gap-4 md:flex-row md:items-start">
+          <div>
+            <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+              {{ location.name }}
+            </h1>
+            <p v-if="location.address" class="mt-1 text-gray-500 dark:text-gray-400">
+              {{ location.address }}
+            </p>
+          </div>
+          <div v-if="isAdmin" class="flex gap-2">
+            <UButton
+              color="neutral"
+              variant="soft"
+              icon="i-heroicons-pencil-square-20-solid"
+              label="Edit"
+              @click="openEdit"
+            />
+            <UButton
+              color="error"
+              variant="soft"
+              icon="i-heroicons-trash-20-solid"
+              label="Delete"
+              @click="openDelete"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-6 grid gap-4 md:grid-cols-2">
+        <UCard>
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-home-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                {{ location.homeItemCount }}
+              </p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">Home items</p>
+            </div>
+          </div>
+        </UCard>
+        <UCard>
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-map-pin-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                {{ location.currentItemCount }}
+              </p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">Items currently here</p>
+            </div>
+          </div>
+        </UCard>
+      </div>
+
+      <UCard>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-cube-20-solid" class="h-5 w-5 text-gray-500" />
+            <h2 class="text-base leading-7 font-semibold text-gray-900 dark:text-white">
+              Items Currently Here
+            </h2>
+          </div>
+        </template>
+
+        <div class="divide-y divide-gray-200 dark:divide-gray-800">
+          <div
+            v-for="item in location.currentItems"
+            :key="item.id"
+            class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+          >
+            <p class="font-medium text-gray-900 dark:text-white">{{ item.name }}</p>
+            <div class="flex gap-2">
+              <UBadge
+                :color="conditionColor[item.condition] || 'neutral'"
+                variant="subtle"
+                size="sm"
+              >
+                {{ item.condition }}
+              </UBadge>
+              <UBadge :color="statusColor[item.status] || 'neutral'" variant="subtle" size="sm">
+                {{ item.status.replace('_', ' ') }}
+              </UBadge>
+            </div>
+          </div>
+
+          <div v-if="location.currentItems.length === 0" class="py-8 text-center text-gray-500">
+            No items currently at this location.
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- Edit Modal -->
+    <UModal v-model:open="isEditOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Edit Location</h3>
+          <UForm :schema="locationSchema" :state="formState" class="space-y-4" @submit="submitEdit">
+            <UFormField label="Name" name="name" required>
+              <UInput v-model="formState.name" placeholder="Location name" class="w-full" />
+            </UFormField>
+            <UFormField label="Address" name="address">
+              <UInput
+                v-model="formState.address"
+                placeholder="Street address (optional)"
+                class="w-full"
+              />
+            </UFormField>
+            <div class="flex justify-end gap-2 pt-2">
+              <UButton variant="soft" color="neutral" @click="isEditOpen = false">Cancel</UButton>
+              <UButton type="submit" :loading="isSubmitting">Save</UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Delete Confirmation Modal -->
+    <UModal v-model:open="isDeleteOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Delete Location</h3>
+          <p class="mb-4 text-gray-500 dark:text-gray-400">
+            Are you sure you want to delete <strong>{{ location?.name }}</strong
+            >? This action cannot be undone.
+          </p>
+          <UAlert
+            v-if="deleteError"
+            icon="i-heroicons-exclamation-triangle-20-solid"
+            color="error"
+            variant="subtle"
+            :title="deleteError"
+            class="mb-4"
+          />
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isDeleteOpen = false">Cancel</UButton>
+            <UButton color="error" :loading="isDeleting" @click="confirmDelete">Delete</UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/app/pages/locations/index.vue
+++ b/app/pages/locations/index.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+  import { z } from 'zod/v4'
+  import { authClient } from '../../utils/auth-client'
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const isAdmin = computed(() => (session.value?.user as Record<string, unknown>)?.role === 'admin')
+
+  const { data: locations, pending, error, refresh } = await useFetch('/api/locations')
+
+  const isFormOpen = ref(false)
+  const isDeleteOpen = ref(false)
+  const editingLocation = ref<{ id: string; name: string; address: string | null } | null>(null)
+  const deletingLocation = ref<{ id: string; name: string } | null>(null)
+  const isSubmitting = ref(false)
+  const isDeleting = ref(false)
+  const deleteError = ref('')
+
+  const toast = useToast()
+
+  const locationSchema = z.object({
+    name: z.string().min(1, 'Name is required').max(200, 'Name must be 200 characters or less'),
+    address: z.string().max(500, 'Address must be 500 characters or less').optional(),
+  })
+
+  type LocationFormState = {
+    name: string
+    address?: string
+  }
+
+  const formState = reactive<LocationFormState>({
+    name: '',
+    address: '',
+  })
+
+  function openCreate() {
+    editingLocation.value = null
+    formState.name = ''
+    formState.address = ''
+    isFormOpen.value = true
+  }
+
+  function openEdit(loc: { id: string; name: string; address: string | null }) {
+    editingLocation.value = loc
+    formState.name = loc.name
+    formState.address = loc.address ?? ''
+    isFormOpen.value = true
+  }
+
+  function openDelete(loc: { id: string; name: string }) {
+    deletingLocation.value = loc
+    deleteError.value = ''
+    isDeleteOpen.value = true
+  }
+
+  async function submitForm() {
+    isSubmitting.value = true
+    try {
+      if (editingLocation.value) {
+        await $fetch(`/api/locations/${editingLocation.value.id}`, {
+          method: 'PUT',
+          body: { name: formState.name, address: formState.address || undefined },
+        })
+        toast.add({ title: 'Location updated', color: 'success' })
+      } else {
+        await $fetch('/api/locations', {
+          method: 'POST',
+          body: { name: formState.name, address: formState.address || undefined },
+        })
+        toast.add({ title: 'Location created', color: 'success' })
+      }
+      isFormOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      toast.add({
+        title: fetchErr.data?.statusMessage || 'Failed to save location',
+        color: 'error',
+      })
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deletingLocation.value) return
+    isDeleting.value = true
+    deleteError.value = ''
+    try {
+      await $fetch(`/api/locations/${deletingLocation.value.id}`, {
+        method: 'DELETE',
+      })
+      toast.add({ title: 'Location deleted', color: 'success' })
+      isDeleteOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      deleteError.value = fetchErr.data?.statusMessage || 'Failed to delete location'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Locations</h1>
+        <p class="mt-1 text-gray-500 dark:text-gray-400">
+          Manage physical locations where equipment is stored.
+        </p>
+      </div>
+      <UButton
+        v-if="isAdmin"
+        color="primary"
+        icon="i-heroicons-plus-20-solid"
+        label="Add Location"
+        @click="openCreate"
+      />
+    </div>
+
+    <UCard>
+      <div v-if="pending" class="space-y-4">
+        <div v-for="i in 3" :key="i" class="flex items-center justify-between py-3">
+          <div class="w-full space-y-2">
+            <USkeleton class="h-4 w-1/3" />
+            <USkeleton class="h-3 w-1/2" />
+          </div>
+        </div>
+      </div>
+
+      <div v-else-if="error">
+        <UAlert
+          icon="i-heroicons-exclamation-triangle-20-solid"
+          color="error"
+          variant="subtle"
+          title="Error loading locations"
+          :description="error.message"
+        />
+      </div>
+
+      <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
+        <NuxtLink
+          v-for="loc in locations"
+          :key="loc.id"
+          :to="`/locations/${loc.id}`"
+          class="-mx-4 flex items-center justify-between px-4 py-4 transition-colors first:pt-0 last:pb-0 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+        >
+          <div class="min-w-0 flex-1">
+            <p class="font-medium text-gray-900 dark:text-white">{{ loc.name }}</p>
+            <p v-if="loc.address" class="mt-0.5 truncate text-sm text-gray-500 dark:text-gray-400">
+              {{ loc.address }}
+            </p>
+          </div>
+          <div class="ml-4 flex items-center gap-3">
+            <div class="flex gap-2">
+              <UBadge variant="subtle" color="primary" size="sm">
+                {{ loc.homeItemCount }} home
+              </UBadge>
+              <UBadge variant="subtle" color="neutral" size="sm">
+                {{ loc.currentItemCount }} current
+              </UBadge>
+            </div>
+            <div v-if="isAdmin" class="flex gap-1" @click.prevent>
+              <UButton
+                color="neutral"
+                variant="ghost"
+                icon="i-heroicons-pencil-square-20-solid"
+                size="sm"
+                @click="openEdit(loc)"
+              />
+              <UButton
+                color="error"
+                variant="ghost"
+                icon="i-heroicons-trash-20-solid"
+                size="sm"
+                @click="openDelete(loc)"
+              />
+            </div>
+          </div>
+        </NuxtLink>
+
+        <div v-if="locations?.length === 0" class="py-8 text-center text-gray-500">
+          No locations found.
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Create/Edit Modal -->
+    <UModal v-model:open="isFormOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+            {{ editingLocation ? 'Edit Location' : 'Add Location' }}
+          </h3>
+          <UForm :schema="locationSchema" :state="formState" class="space-y-4" @submit="submitForm">
+            <UFormField label="Name" name="name" required>
+              <UInput v-model="formState.name" placeholder="Location name" class="w-full" />
+            </UFormField>
+            <UFormField label="Address" name="address">
+              <UInput
+                v-model="formState.address"
+                placeholder="Street address (optional)"
+                class="w-full"
+              />
+            </UFormField>
+            <div class="flex justify-end gap-2 pt-2">
+              <UButton variant="soft" color="neutral" @click="isFormOpen = false">Cancel</UButton>
+              <UButton type="submit" :loading="isSubmitting">
+                {{ editingLocation ? 'Save' : 'Create' }}
+              </UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Delete Confirmation Modal -->
+    <UModal v-model:open="isDeleteOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Delete Location</h3>
+          <p class="mb-4 text-gray-500 dark:text-gray-400">
+            Are you sure you want to delete <strong>{{ deletingLocation?.name }}</strong
+            >? This action cannot be undone.
+          </p>
+          <UAlert
+            v-if="deleteError"
+            icon="i-heroicons-exclamation-triangle-20-solid"
+            color="error"
+            variant="subtle"
+            :title="deleteError"
+            class="mb-4"
+          />
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isDeleteOpen = false">Cancel</UButton>
+            <UButton color="error" :loading="isDeleting" @click="confirmDelete">Delete</UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -33,11 +33,11 @@ function isEmailAllowed(email: string): boolean {
 
 Three roles, stored on the User model:
 
-| Role | Permissions |
-|---|---|
-| **admin** | Full CRUD on locations, items, users. Check in/out items. |
-| **supervisor** | Check in/out items (for self and others). Read all data. |
-| **employee** | Read-only. Can view items, locations, own checkout history. Cannot perform check-in/out. |
+| Role           | Permissions                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| **admin**      | Full CRUD on locations, items, users. Check in/out items.                                |
+| **supervisor** | Check in/out items (for self and others). Read all data.                                 |
+| **employee**   | Read-only. Can view items, locations, own checkout history. Cannot perform check-in/out. |
 
 ### Where roles are enforced
 
@@ -47,11 +47,11 @@ Three roles, stored on the User model:
 
 ## User Status & Login
 
-| Status | Can log in? | Notes |
-|---|---|---|
-| `active` | Yes | Normal access |
-| `on_leave` | Yes | Can still log in (e.g., to return items), but UI shows indicator |
-| `inactive` | No | Login blocked. Admin must reactivate. |
+| Status     | Can log in? | Notes                                                            |
+| ---------- | ----------- | ---------------------------------------------------------------- |
+| `active`   | Yes         | Normal access                                                    |
+| `on_leave` | Yes         | Can still log in (e.g., to return items), but UI shows indicator |
+| `inactive` | No          | Login blocked. Admin must reactivate.                            |
 
 Inactive users should be blocked at the auth level — either via a Better Auth hook that checks status before completing sign-in, or by checking status in the global middleware and redirecting to an "account inactive" page.
 
@@ -83,7 +83,7 @@ if (!session.value && to.path !== '/auth') {
 ```typescript
 // In auth.vue, after successful signIn
 const route = useRoute()
-const redirectTo = route.query.redirect as string || '/'
+const redirectTo = (route.query.redirect as string) || '/'
 await navigateTo(redirectTo, { external: true })
 ```
 
@@ -91,26 +91,27 @@ await navigateTo(redirectTo, { external: true })
 
 ```typescript
 if (session.value && to.path === '/auth') {
-  const redirect = to.query.redirect as string || '/'
+  const redirect = (to.query.redirect as string) || '/'
   return navigateTo(redirect)
 }
 ```
 
 ## Session Validation (Server-Side)
 
-All API routes validate the session before processing:
+All API routes use the `requireAuth` utility (`server/utils/require-auth.ts`) for authentication and role checking:
 
 ```typescript
-const session = await auth.api.getSession({ headers: event.headers })
+// Authentication only (any logged-in user)
+const session = await requireAuth(event)
 
-if (!session) {
-  throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-}
-
-// For role-restricted endpoints:
-const user = await prisma.user.findUnique({ where: { id: session.user.id } })
-
-if (user.role !== 'admin') {
-  throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
-}
+// Authentication + role check (throws 403 if role doesn't match)
+const session = await requireAuth(event, ['admin'])
+const session = await requireAuth(event, ['admin', 'supervisor'])
 ```
+
+`requireAuth` returns the session object (with `user` and `session` properties) or throws:
+
+- **401 Unauthorized** — no valid session
+- **403 Forbidden** — session exists but user's role is not in the allowed list
+
+The returned `session.user` includes `id`, `email`, `name`, `role`, and `status` fields.

--- a/server/api/locations/[id].delete.ts
+++ b/server/api/locations/[id].delete.ts
@@ -1,0 +1,34 @@
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const id = getRouterParam(event, 'id')
+
+  const existing = await prisma.location.findUnique({
+    where: { id },
+    include: {
+      _count: {
+        select: {
+          homeItems: true,
+          currentItems: true,
+        },
+      },
+    },
+  })
+
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  const totalItems = existing._count.homeItems + existing._count.currentItems
+  if (totalItems > 0) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Cannot delete location: ${totalItems} items are still assigned to it.`,
+    })
+  }
+
+  await prisma.location.delete({ where: { id } })
+
+  setResponseStatus(event, 204)
+  return null
+})

--- a/server/api/locations/[id].get.ts
+++ b/server/api/locations/[id].get.ts
@@ -1,0 +1,38 @@
+export default defineEventHandler(async (event) => {
+  await requireAuth(event)
+
+  const id = getRouterParam(event, 'id')
+
+  const location = await prisma.location.findUnique({
+    where: { id },
+    include: {
+      _count: {
+        select: {
+          homeItems: true,
+          currentItems: true,
+        },
+      },
+      currentItems: {
+        select: {
+          id: true,
+          name: true,
+          condition: true,
+          status: true,
+        },
+      },
+    },
+  })
+
+  if (!location) {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  return {
+    id: location.id,
+    name: location.name,
+    address: location.address,
+    homeItemCount: location._count.homeItems,
+    currentItemCount: location._count.currentItems,
+    currentItems: location.currentItems,
+  }
+})

--- a/server/api/locations/[id].put.ts
+++ b/server/api/locations/[id].put.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod/v4'
+
+const updateLocationSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200).optional(),
+  address: z.string().max(500).nullable().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const result = updateLocationSchema.safeParse(body)
+
+  if (!result.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation error',
+      data: result.error.issues,
+    })
+  }
+
+  const existing = await prisma.location.findUnique({ where: { id } })
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  const location = await prisma.location.update({
+    where: { id },
+    data: result.data,
+  })
+
+  return location
+})

--- a/server/api/locations/index.get.ts
+++ b/server/api/locations/index.get.ts
@@ -1,0 +1,23 @@
+export default defineEventHandler(async (event) => {
+  await requireAuth(event)
+
+  const locations = await prisma.location.findMany({
+    include: {
+      _count: {
+        select: {
+          homeItems: true,
+          currentItems: true,
+        },
+      },
+    },
+    orderBy: { name: 'asc' },
+  })
+
+  return locations.map((loc) => ({
+    id: loc.id,
+    name: loc.name,
+    address: loc.address,
+    homeItemCount: loc._count.homeItems,
+    currentItemCount: loc._count.currentItems,
+  }))
+})

--- a/server/api/locations/index.post.ts
+++ b/server/api/locations/index.post.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod/v4'
+
+const createLocationSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  address: z.string().max(500).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const body = await readBody(event)
+  const result = createLocationSchema.safeParse(body)
+
+  if (!result.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation error',
+      data: result.error.issues,
+    })
+  }
+
+  const location = await prisma.location.create({
+    data: {
+      name: result.data.name,
+      address: result.data.address,
+    },
+  })
+
+  setResponseStatus(event, 201)
+  return location
+})

--- a/server/utils/require-auth.ts
+++ b/server/utils/require-auth.ts
@@ -1,0 +1,38 @@
+import type { H3Event } from 'h3'
+import { auth } from './auth'
+
+type Role = 'admin' | 'supervisor' | 'employee'
+
+interface AuthSession {
+  user: {
+    id: string
+    email: string
+    name: string
+    role: string
+    status: string
+    [key: string]: unknown
+  }
+  session: {
+    id: string
+    [key: string]: unknown
+  }
+}
+
+export async function requireAuth(event: H3Event, roles?: Role[]): Promise<AuthSession> {
+  const session = await auth.api.getSession({
+    headers: event.headers,
+  })
+
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  if (roles && roles.length > 0) {
+    const userRole = (session.user as Record<string, unknown>).role as string
+    if (!roles.includes(userRole as Role)) {
+      throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+    }
+  }
+
+  return session as unknown as AuthSession
+}


### PR DESCRIPTION
## Summary
- Full CRUD API for locations (`GET/POST/PUT/DELETE /api/locations`) with role-based access (admin-only mutations) and Zod validation
- Location list page (`/locations`) with item counts, admin create/edit modals, and delete confirmation with conflict protection (409 when items are assigned)
- Location detail page (`/locations/[id]`) showing item counts, current items list, and admin edit/delete actions
- Reusable `requireAuth` server utility for session + role checking (returns 401/403)
- Updated app header with "TWC Inventory" branding and navigation

## Test plan
- [ ] Verify `GET /api/locations` returns all locations with correct home/current item counts
- [ ] Verify `GET /api/locations/[id]` returns location detail with current items
- [ ] Verify `POST /api/locations` creates a location (admin only, validates name required + max lengths)
- [ ] Verify `PUT /api/locations/[id]` updates a location (admin only)
- [ ] Verify `DELETE /api/locations/[id]` blocks deletion when items are assigned (409), succeeds otherwise
- [ ] Verify non-admin users get 403 on mutating endpoints
- [ ] Verify `/locations` page shows read-only view for non-admin, CRUD actions for admin
- [ ] Verify `/locations/[id]` detail page renders correctly with item counts and badges

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)