### PR TITLE
Add user management API routes, admin UI, and profile page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQLite, and Nuxt UI v3. Uses pnpm as the package manager.
+TWC Inventory — an inventory management app for The Warren Center. Built with Nuxt 4, Better Auth (email OTP authentication), Prisma ORM, SQLite, and Nuxt UI v3. Uses pnpm as the package manager.
 
 ## Common Commands
 
@@ -23,20 +23,31 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow) and `/` (dashboard with user list + profile picture upload)
+- **Pages**:
+  - `/auth` — email OTP login flow
+  - `/` — dashboard (navigation hub with role-aware cards)
+  - `/profile` — current user's profile with photo upload, logout, checkout history
+  - `/users` — user list with filters (admin/supervisor only), CRUD modals (admin only)
+  - `/users/[id]` — user detail with checkout stats and history
+  - `/locations` — location list with CRUD modals (admin only)
+  - `/locations/[id]` — location detail with item counts and current items
 
 ### Backend (`server/`)
 
 - **Auth handler**: `server/api/auth/[...all].ts` — catch-all route delegating to Better Auth
-- **Auth config**: `server/utils/auth.ts` — Better Auth setup with Prisma adapter (SQLite) and emailOTP plugin using Nodemailer (Gmail SMTP)
+- **Auth config**: `server/utils/auth.ts` — Better Auth setup with Prisma adapter (SQLite), emailOTP plugin, domain restriction (`isEmailAllowed`)
+- **Auth utility**: `server/utils/require-auth.ts` — `requireAuth(event, roles?)` for session + role checking (returns 401/403)
+- **Display name utility**: `server/utils/display-name.ts` — `getDisplayName(user)` computes preferred-over-legal name
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
-- **API routes**: `server/api/users/` — user listing, profile image serving, and file upload (multipart form)
+- **API routes**:
+  - `server/api/users/` — full CRUD, profile, history, photo upload
+  - `server/api/locations/` — full CRUD with item counts
 
 ### Database (`prisma/`)
 
 - **SQLite** via `better-sqlite3` driver adapter (not the default Prisma SQLite driver)
 - **Prisma client output**: `prisma/generated/` (custom output path)
-- **Schema models**: User, Session, Account, Verification (Better Auth tables)
+- **Schema models**: User, Session, Account, Verification (Better Auth tables), Location, Item, CheckoutLog (inventory tables)
 - **Seed**: `prisma/seed.ts` run via `tsx`
 - **Config**: `prisma.config.ts` at project root
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -20,12 +20,37 @@
         class="sticky top-0 z-50 border-b border-gray-200 bg-white/75 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/75"
       >
         <UContainer class="flex h-16 items-center justify-between">
-          <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
-            <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
-            <span>Nuxt Template</span>
-          </NuxtLink>
+          <div class="flex items-center gap-6">
+            <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
+              <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
+              <span>TWC Inventory</span>
+            </NuxtLink>
+            <nav class="hidden items-center gap-1 md:flex">
+              <NuxtLink
+                to="/locations"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                active-class="text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950"
+              >
+                Locations
+              </NuxtLink>
+              <NuxtLink
+                to="/users"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                active-class="text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950"
+              >
+                Users
+              </NuxtLink>
+            </nav>
+          </div>
 
           <div class="flex items-center gap-2">
+            <NuxtLink
+              to="/profile"
+              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              active-class="text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950"
+            >
+              Profile
+            </NuxtLink>
             <UButton
               :icon="isDark ? 'i-heroicons-moon-20-solid' : 'i-heroicons-sun-20-solid'"
               color="neutral"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,197 +1,54 @@
 <script setup lang="ts">
   import { authClient } from '../utils/auth-client'
 
-  const { data: users, pending, error } = await useFetch('/api/users')
-
-  const selectedFile = ref<File | null>(null)
-  const imagePreview = ref<string>('')
-  const isUploading = ref(false)
-  const isModalOpen = ref(false)
-
-  async function logout() {
-    await authClient.signOut()
-    await navigateTo('/auth', { external: true })
-  }
-
-  function getImageLink(user: { image: boolean; id: string }) {
-    return user.image ? 'api/users/' + user.id + '/profile' : undefined
-  }
-
-  function handleImageUpload(event: Event) {
-    const target = event.target as HTMLInputElement
-    const files = target.files as FileList
-
-    if (!files || files.length === 0) return
-
-    const file = files[0]
-
-    if (!file?.type.startsWith('image/')) {
-      return
-    }
-
-    selectedFile.value = file
-
-    const reader = new FileReader()
-    reader.onload = (e) => {
-      imagePreview.value = e.target?.result as string
-    }
-    reader.readAsDataURL(file)
-  }
-
-  const openModal = () => {
-    isModalOpen.value = true
-  }
-
-  const closeModal = () => {
-    isModalOpen.value = false
-  }
-
-  async function updatePfp() {
-    if (!selectedFile.value) return
-
-    isUploading.value = true
-
-    try {
-      const formData = new FormData()
-      formData.append('file', selectedFile.value)
-
-      await $fetch('/api/users/upload', {
-        method: 'POST',
-        body: formData,
-      })
-
-      // Refresh users data to show updated profile picture
-      await refreshNuxtData()
-
-      // Reset state
-      selectedFile.value = null
-      imagePreview.value = ''
-      isModalOpen.value = false
-    } catch (error) {
-      console.error('Upload failed:', error)
-    } finally {
-      isUploading.value = false
-    }
-  }
+  const { data: session } = await authClient.useSession(useFetch)
+  const user = computed(() => session.value?.user as Record<string, unknown> | undefined)
+  const userRole = computed(() => user.value?.role as string)
 </script>
 
 <template>
   <UContainer class="py-10">
-    <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
-      <div>
-        <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Dashboard</h1>
-        <p class="mt-1 text-gray-500 dark:text-gray-400">
-          Manage your application users and settings.
-        </p>
-      </div>
-      <div class="flex justify-between gap-4 md:items-center">
-        <UModal :open="isModalOpen">
-          <UButton
-            color="success"
-            variant="soft"
-            icon="i-heroicons-arrow-up-on-square-20-solid"
-            label="Update Profile Picture"
-            @click="openModal"
-          />
-
-          <template #content>
-            <div class="m-12 space-y-4">
-              <h3 class="text-lg font-medium text-gray-900 dark:text-white">
-                Update Profile Picture
-              </h3>
-
-              <div v-if="imagePreview" class="flex justify-center">
-                <UAvatar :src="imagePreview" size="3xl" />
-              </div>
-
-              <div>
-                <input
-                  type="file"
-                  accept="image/*"
-                  class="file:bg-primary-50 file:text-brand4 hover:file:bg-primary-100 block w-full cursor-pointer text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold"
-                  @change="handleImageUpload"
-                />
-              </div>
-
-              <div class="flex justify-end gap-2">
-                <UButton variant="soft" @click="closeModal"> Cancel </UButton>
-                <UButton
-                  color="success"
-                  :loading="isUploading"
-                  :disabled="!selectedFile"
-                  @click="updatePfp"
-                >
-                  Upload
-                </UButton>
-              </div>
-            </div>
-          </template>
-        </UModal>
-        <UButton
-          color="error"
-          variant="soft"
-          icon="i-heroicons-arrow-right-on-rectangle-20-solid"
-          label="Logout"
-          @click="logout"
-        />
-      </div>
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Dashboard</h1>
+      <p class="mt-1 text-gray-500 dark:text-gray-400">Welcome back, {{ user?.name || 'User' }}.</p>
     </div>
 
-    <UCard class="w-full">
-      <template #header>
-        <div class="flex items-center justify-between">
-          <div class="flex items-center gap-2">
-            <UIcon name="i-heroicons-users-20-solid" class="h-5 w-5 text-gray-500" />
-            <h2 class="text-base leading-7 font-semibold text-gray-900 dark:text-white">
-              Registered Users
-            </h2>
-          </div>
-          <UBadge variant="subtle" color="primary" size="md">{{ users?.length || 0 }} Users</UBadge>
-        </div>
-      </template>
-
-      <div v-if="pending" class="space-y-4">
-        <div v-for="i in 3" :key="i" class="flex items-center justify-between py-2">
-          <div class="flex w-full items-center gap-3">
-            <USkeleton class="h-10 w-10 rounded-full" />
-            <div class="w-full max-w-[200px] space-y-2">
-              <USkeleton class="h-4 w-full" />
-              <USkeleton class="h-3 w-2/3" />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div v-else-if="error">
-        <UAlert
-          icon="i-heroicons-exclamation-triangle-20-solid"
-          color="error"
-          variant="subtle"
-          title="Error loading users"
-          :description="error.message"
-        />
-      </div>
-
-      <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
-        <div
-          v-for="user in users"
-          :key="user.id"
-          class="flex items-center justify-between py-4 first:pt-0 last:pb-0"
-        >
+    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <NuxtLink to="/profile">
+        <UCard class="transition-shadow hover:shadow-md">
           <div class="flex items-center gap-3">
-            <UAvatar :src="getImageLink(user)" :alt="user.name" size="md" :as="{ img: 'img' }" />
+            <UIcon name="i-heroicons-user-circle-20-solid" class="text-primary-500 h-8 w-8" />
             <div>
-              <p class="font-medium text-gray-900 dark:text-white">{{ user.name }}</p>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{{ user.email }}</p>
+              <p class="font-semibold text-gray-900 dark:text-white">My Profile</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">View your profile and history</p>
             </div>
           </div>
-          <UBadge :color="user.emailVerified ? 'success' : 'warning'" variant="subtle" size="sm">
-            {{ user.emailVerified ? 'Verified' : 'Pending' }}
-          </UBadge>
-        </div>
+        </UCard>
+      </NuxtLink>
 
-        <div v-if="users?.length === 0" class="py-8 text-center text-gray-500">No users found.</div>
-      </div>
-    </UCard>
+      <NuxtLink v-if="userRole === 'admin' || userRole === 'supervisor'" to="/users">
+        <UCard class="transition-shadow hover:shadow-md">
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-users-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="font-semibold text-gray-900 dark:text-white">Users</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">Manage user accounts</p>
+            </div>
+          </div>
+        </UCard>
+      </NuxtLink>
+
+      <NuxtLink to="/locations">
+        <UCard class="transition-shadow hover:shadow-md">
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-map-pin-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="font-semibold text-gray-900 dark:text-white">Locations</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">View and manage locations</p>
+            </div>
+          </div>
+        </UCard>
+      </NuxtLink>
+    </div>
   </UContainer>
 </template>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+  import { authClient } from '../utils/auth-client'
+
+  interface HistoryEntry {
+    id: string
+    item: { id: string; name: string }
+    checkedOutAt: string
+    checkedOutFromLocation: { id: string; name: string }
+    checkedInAt: string | null
+    checkedInAtLocation: { id: string; name: string } | null
+    conditionOnReturn: string | null
+  }
+
+  const { data: user, pending, error } = await useFetch('/api/users/me')
+
+  const { data: history } = await useFetch<HistoryEntry[]>(
+    computed(() => `/api/users/${user.value?.id}/history`),
+    { immediate: !!user.value }
+  )
+
+  const selectedFile = ref<File | null>(null)
+  const imagePreview = ref<string>('')
+  const isUploading = ref(false)
+  const isModalOpen = ref(false)
+
+  async function logout() {
+    await authClient.signOut()
+    await navigateTo('/auth', { external: true })
+  }
+
+  function getImageLink() {
+    return user.value?.image ? `/api/users/${user.value.id}/profile` : undefined
+  }
+
+  function handleImageUpload(event: Event) {
+    const target = event.target as HTMLInputElement
+    const files = target.files as FileList
+    if (!files || files.length === 0) return
+    const file = files[0]
+    if (!file?.type.startsWith('image/')) return
+
+    selectedFile.value = file
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      imagePreview.value = e.target?.result as string
+    }
+    reader.readAsDataURL(file)
+  }
+
+  async function uploadPfp() {
+    if (!selectedFile.value) return
+    isUploading.value = true
+    try {
+      const formData = new FormData()
+      formData.append('file', selectedFile.value)
+      await $fetch('/api/users/upload', { method: 'POST', body: formData })
+      await refreshNuxtData()
+      selectedFile.value = null
+      imagePreview.value = ''
+      isModalOpen.value = false
+    } catch (err) {
+      console.error('Upload failed:', err)
+    } finally {
+      isUploading.value = false
+    }
+  }
+
+  type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+  const roleColor: Record<string, BadgeColor> = {
+    admin: 'error',
+    supervisor: 'warning',
+    employee: 'info',
+  }
+
+  const statusColor: Record<string, BadgeColor> = {
+    active: 'success',
+    on_leave: 'warning',
+    inactive: 'neutral',
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div v-if="pending" class="space-y-4">
+      <USkeleton class="h-8 w-1/3" />
+      <USkeleton class="h-4 w-1/2" />
+    </div>
+
+    <div v-else-if="error">
+      <UAlert
+        icon="i-heroicons-exclamation-triangle-20-solid"
+        color="error"
+        variant="subtle"
+        title="Error loading profile"
+        :description="error.message"
+      />
+    </div>
+
+    <div v-else-if="user">
+      <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-start">
+        <div class="flex items-center gap-4">
+          <UAvatar :src="getImageLink()" :alt="user.displayName" size="xl" />
+          <div>
+            <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+              {{ user.displayName }}
+            </h1>
+            <p class="mt-0.5 text-gray-500 dark:text-gray-400">{{ user.email }}</p>
+            <div class="mt-2 flex gap-2">
+              <UBadge :color="roleColor[user.role] || 'neutral'" variant="subtle">
+                {{ user.role }}
+              </UBadge>
+              <UBadge :color="statusColor[user.status] || 'neutral'" variant="subtle">
+                {{ user.status.replace('_', ' ') }}
+              </UBadge>
+            </div>
+          </div>
+        </div>
+        <div class="flex gap-2">
+          <UModal :open="isModalOpen">
+            <UButton
+              color="neutral"
+              variant="soft"
+              icon="i-heroicons-camera-20-solid"
+              label="Update Photo"
+              @click="isModalOpen = true"
+            />
+            <template #content>
+              <div class="space-y-4 p-6">
+                <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+                  Update Profile Picture
+                </h3>
+                <div v-if="imagePreview" class="flex justify-center">
+                  <UAvatar :src="imagePreview" size="3xl" />
+                </div>
+                <input
+                  type="file"
+                  accept="image/*"
+                  class="file:bg-primary-50 file:text-brand4 hover:file:bg-primary-100 block w-full cursor-pointer text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold"
+                  @change="handleImageUpload"
+                />
+                <div class="flex justify-end gap-2">
+                  <UButton variant="soft" color="neutral" @click="isModalOpen = false">
+                    Cancel
+                  </UButton>
+                  <UButton
+                    color="primary"
+                    :loading="isUploading"
+                    :disabled="!selectedFile"
+                    @click="uploadPfp"
+                  >
+                    Upload
+                  </UButton>
+                </div>
+              </div>
+            </template>
+          </UModal>
+          <UButton
+            color="error"
+            variant="soft"
+            icon="i-heroicons-arrow-right-on-rectangle-20-solid"
+            label="Logout"
+            @click="logout"
+          />
+        </div>
+      </div>
+
+      <!-- Checkout History -->
+      <UCard>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-heroicons-clipboard-document-list-20-solid"
+              class="h-5 w-5 text-gray-500"
+            />
+            <h2 class="text-base leading-7 font-semibold text-gray-900 dark:text-white">
+              My Checkout History
+            </h2>
+          </div>
+        </template>
+
+        <div class="divide-y divide-gray-200 dark:divide-gray-800">
+          <div
+            v-for="log in history"
+            :key="log.id"
+            class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+          >
+            <div>
+              <p class="font-medium text-gray-900 dark:text-white">{{ log.item.name }}</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                From {{ log.checkedOutFromLocation.name }} &mdash;
+                {{ new Date(log.checkedOutAt).toLocaleDateString() }}
+              </p>
+            </div>
+            <div>
+              <UBadge v-if="!log.checkedInAt" color="warning" variant="subtle" size="sm">
+                Checked out
+              </UBadge>
+              <UBadge v-else color="success" variant="subtle" size="sm">
+                Returned {{ new Date(log.checkedInAt).toLocaleDateString() }}
+              </UBadge>
+            </div>
+          </div>
+
+          <div v-if="!history || history.length === 0" class="py-8 text-center text-gray-500">
+            No checkout history yet.
+          </div>
+        </div>
+      </UCard>
+    </div>
+  </UContainer>
+</template>

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -1,0 +1,387 @@
+<script setup lang="ts">
+  import { z } from 'zod/v4'
+  import { authClient } from '../../utils/auth-client'
+
+  const route = useRoute()
+  const userId = route.params.id as string
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const userRole = computed(() => (session.value?.user as Record<string, unknown>)?.role as string)
+  const isAdmin = computed(() => userRole.value === 'admin')
+
+  interface UserDetail {
+    id: string
+    email: string
+    name: string
+    legalFirstName: string | null
+    legalLastName: string | null
+    preferredFirstName: string | null
+    preferredLastName: string | null
+    displayName: string
+    role: string
+    status: string
+    image: boolean
+    emailVerified: boolean
+    createdAt: string
+    currentItemsHeld: number
+    pastCheckoutCount: number
+  }
+
+  interface HistoryEntry {
+    id: string
+    item: { id: string; name: string }
+    checkedOutAt: string
+    checkedOutFromLocation: { id: string; name: string }
+    checkedInAt: string | null
+    checkedInAtLocation: { id: string; name: string } | null
+    conditionOnReturn: string | null
+  }
+
+  const { data: user, pending, error, refresh } = await useFetch<UserDetail>(`/api/users/${userId}`)
+
+  const { data: history } = await useFetch<HistoryEntry[]>(`/api/users/${userId}/history`)
+
+  const isEditOpen = ref(false)
+  const isDeleteOpen = ref(false)
+  const isSubmitting = ref(false)
+  const isDeleting = ref(false)
+  const deleteError = ref('')
+
+  const toast = useToast()
+
+  const editSchema = z.object({
+    legalFirstName: z.string().min(1, 'Legal first name is required'),
+    legalLastName: z.string().min(1, 'Legal last name is required'),
+    preferredFirstName: z.string().optional(),
+    preferredLastName: z.string().optional(),
+    role: z.enum(['admin', 'supervisor', 'employee']),
+    status: z.enum(['active', 'on_leave', 'inactive']),
+  })
+
+  type EditFormState = {
+    legalFirstName: string
+    legalLastName: string
+    preferredFirstName: string
+    preferredLastName: string
+    role: 'admin' | 'supervisor' | 'employee'
+    status: 'active' | 'on_leave' | 'inactive'
+  }
+
+  const formState = reactive<EditFormState>({
+    legalFirstName: '',
+    legalLastName: '',
+    preferredFirstName: '',
+    preferredLastName: '',
+    role: 'employee',
+    status: 'active',
+  })
+
+  function openEdit() {
+    if (!user.value) return
+    Object.assign(formState, {
+      legalFirstName: user.value.legalFirstName || '',
+      legalLastName: user.value.legalLastName || '',
+      preferredFirstName: user.value.preferredFirstName || '',
+      preferredLastName: user.value.preferredLastName || '',
+      role: user.value.role || 'employee',
+      status: user.value.status || 'active',
+    })
+    isEditOpen.value = true
+  }
+
+  function openDelete() {
+    deleteError.value = ''
+    isDeleteOpen.value = true
+  }
+
+  async function submitEdit() {
+    isSubmitting.value = true
+    try {
+      await $fetch(`/api/users/${userId}`, {
+        method: 'PUT',
+        body: {
+          legalFirstName: formState.legalFirstName,
+          legalLastName: formState.legalLastName,
+          preferredFirstName: formState.preferredFirstName || null,
+          preferredLastName: formState.preferredLastName || null,
+          role: formState.role,
+          status: formState.status,
+        },
+      })
+      toast.add({ title: 'User updated', color: 'success' })
+      isEditOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      toast.add({
+        title: fetchErr.data?.statusMessage || 'Failed to update user',
+        color: 'error',
+      })
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  async function confirmDelete() {
+    isDeleting.value = true
+    deleteError.value = ''
+    try {
+      await $fetch(`/api/users/${userId}`, { method: 'DELETE' })
+      toast.add({ title: 'User deleted', color: 'success' })
+      await navigateTo('/users')
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      deleteError.value = fetchErr.data?.statusMessage || 'Failed to delete user'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+  const roleColor: Record<string, BadgeColor> = {
+    admin: 'error',
+    supervisor: 'warning',
+    employee: 'info',
+  }
+
+  const statusColor: Record<string, BadgeColor> = {
+    active: 'success',
+    on_leave: 'warning',
+    inactive: 'neutral',
+  }
+
+  function getImageLink(u: { image: boolean; id: string }) {
+    return u.image ? `/api/users/${u.id}/profile` : undefined
+  }
+
+  function hasPreferredName(u: NonNullable<typeof user.value>) {
+    return (
+      (u.preferredFirstName && u.preferredFirstName !== u.legalFirstName) ||
+      (u.preferredLastName && u.preferredLastName !== u.legalLastName)
+    )
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div v-if="pending" class="space-y-4">
+      <USkeleton class="h-8 w-1/3" />
+      <USkeleton class="h-4 w-1/2" />
+      <USkeleton class="mt-6 h-40 w-full" />
+    </div>
+
+    <div v-else-if="error">
+      <UAlert
+        icon="i-heroicons-exclamation-triangle-20-solid"
+        color="error"
+        variant="subtle"
+        title="Error loading user"
+        :description="error.message"
+      />
+      <UButton class="mt-4" variant="soft" to="/users" icon="i-heroicons-arrow-left-20-solid">
+        Back to users
+      </UButton>
+    </div>
+
+    <div v-else-if="user">
+      <div class="mb-6">
+        <NuxtLink
+          to="/users"
+          class="mb-4 flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <UIcon name="i-heroicons-arrow-left-20-solid" class="h-4 w-4" />
+          Back to users
+        </NuxtLink>
+
+        <div class="flex flex-col justify-between gap-4 md:flex-row md:items-start">
+          <div class="flex items-center gap-4">
+            <UAvatar :src="getImageLink(user)" :alt="user.displayName" size="xl" />
+            <div>
+              <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+                {{ user.displayName }}
+              </h1>
+              <p v-if="hasPreferredName(user)" class="text-sm text-gray-500 dark:text-gray-400">
+                Legal name: {{ user.legalFirstName }} {{ user.legalLastName }}
+              </p>
+              <p class="mt-0.5 text-gray-500 dark:text-gray-400">{{ user.email }}</p>
+              <div class="mt-2 flex gap-2">
+                <UBadge :color="roleColor[user.role] || 'neutral'" variant="subtle">
+                  {{ user.role }}
+                </UBadge>
+                <UBadge :color="statusColor[user.status] || 'neutral'" variant="subtle">
+                  {{ user.status.replace('_', ' ') }}
+                </UBadge>
+              </div>
+            </div>
+          </div>
+          <div v-if="isAdmin" class="flex gap-2">
+            <UButton
+              color="neutral"
+              variant="soft"
+              icon="i-heroicons-pencil-square-20-solid"
+              label="Edit"
+              @click="openEdit"
+            />
+            <UButton
+              color="error"
+              variant="soft"
+              icon="i-heroicons-trash-20-solid"
+              label="Delete"
+              @click="openDelete"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="mb-6 grid gap-4 md:grid-cols-2">
+        <UCard>
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-cube-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                {{ user.currentItemsHeld }}
+              </p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">Items currently held</p>
+            </div>
+          </div>
+        </UCard>
+        <UCard>
+          <div class="flex items-center gap-3">
+            <UIcon name="i-heroicons-clock-20-solid" class="text-primary-500 h-8 w-8" />
+            <div>
+              <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                {{ user.pastCheckoutCount }}
+              </p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">Past checkouts</p>
+            </div>
+          </div>
+        </UCard>
+      </div>
+
+      <!-- Checkout History -->
+      <UCard>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-heroicons-clipboard-document-list-20-solid"
+              class="h-5 w-5 text-gray-500"
+            />
+            <h2 class="text-base leading-7 font-semibold text-gray-900 dark:text-white">
+              Checkout History
+            </h2>
+          </div>
+        </template>
+
+        <div class="divide-y divide-gray-200 dark:divide-gray-800">
+          <div
+            v-for="log in history"
+            :key="log.id"
+            class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+          >
+            <div>
+              <p class="font-medium text-gray-900 dark:text-white">{{ log.item.name }}</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                From {{ log.checkedOutFromLocation.name }} &mdash;
+                {{ new Date(log.checkedOutAt).toLocaleDateString() }}
+              </p>
+            </div>
+            <div>
+              <UBadge v-if="!log.checkedInAt" color="warning" variant="subtle" size="sm">
+                Checked out
+              </UBadge>
+              <UBadge v-else color="success" variant="subtle" size="sm">
+                Returned {{ new Date(log.checkedInAt).toLocaleDateString() }}
+              </UBadge>
+            </div>
+          </div>
+
+          <div v-if="!history || history.length === 0" class="py-8 text-center text-gray-500">
+            No checkout history.
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- Edit Modal -->
+    <UModal v-model:open="isEditOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Edit User</h3>
+          <UForm :schema="editSchema" :state="formState" class="space-y-4" @submit="submitEdit">
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Legal First Name" name="legalFirstName" required>
+                <UInput v-model="formState.legalFirstName" class="w-full" />
+              </UFormField>
+              <UFormField label="Legal Last Name" name="legalLastName" required>
+                <UInput v-model="formState.legalLastName" class="w-full" />
+              </UFormField>
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Preferred First Name" name="preferredFirstName">
+                <UInput v-model="formState.preferredFirstName" class="w-full" />
+              </UFormField>
+              <UFormField label="Preferred Last Name" name="preferredLastName">
+                <UInput v-model="formState.preferredLastName" class="w-full" />
+              </UFormField>
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Role" name="role" required>
+                <USelect
+                  v-model="formState.role"
+                  :items="[
+                    { label: 'Admin', value: 'admin' },
+                    { label: 'Supervisor', value: 'supervisor' },
+                    { label: 'Employee', value: 'employee' },
+                  ]"
+                  class="w-full"
+                />
+              </UFormField>
+              <UFormField label="Status" name="status" required>
+                <USelect
+                  v-model="formState.status"
+                  :items="[
+                    { label: 'Active', value: 'active' },
+                    { label: 'On Leave', value: 'on_leave' },
+                    { label: 'Inactive', value: 'inactive' },
+                  ]"
+                  class="w-full"
+                />
+              </UFormField>
+            </div>
+            <div class="flex justify-end gap-2 pt-2">
+              <UButton variant="soft" color="neutral" @click="isEditOpen = false">Cancel</UButton>
+              <UButton type="submit" :loading="isSubmitting">Save</UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Delete Confirmation Modal -->
+    <UModal v-model:open="isDeleteOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Delete User</h3>
+          <p class="mb-4 text-gray-500 dark:text-gray-400">
+            Are you sure you want to delete <strong>{{ user?.displayName }}</strong
+            >? This action cannot be undone.
+          </p>
+          <UAlert
+            v-if="deleteError"
+            icon="i-heroicons-exclamation-triangle-20-solid"
+            color="error"
+            variant="subtle"
+            :title="deleteError"
+            class="mb-4"
+          />
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isDeleteOpen = false">Cancel</UButton>
+            <UButton color="error" :loading="isDeleting" @click="confirmDelete">Delete</UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/app/pages/users/index.vue
+++ b/app/pages/users/index.vue
@@ -1,0 +1,381 @@
+<script setup lang="ts">
+  import { z } from 'zod/v4'
+  import { authClient } from '../../utils/auth-client'
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const userRole = computed(() => (session.value?.user as Record<string, unknown>)?.role as string)
+  const isAdmin = computed(() => userRole.value === 'admin')
+
+  // Redirect employees away
+  if (userRole.value === 'employee') {
+    await navigateTo('/')
+  }
+
+  const roleFilter = ref('')
+  const statusFilter = ref('')
+  const search = ref('')
+
+  const queryParams = computed(() => {
+    const params: Record<string, string> = {}
+    if (roleFilter.value) params.role = roleFilter.value
+    if (statusFilter.value) params.status = statusFilter.value
+    if (search.value) params.search = search.value
+    return params
+  })
+
+  const {
+    data: users,
+    pending,
+    error,
+    refresh,
+  } = await useFetch('/api/users', { query: queryParams })
+
+  const isFormOpen = ref(false)
+  const isDeleteOpen = ref(false)
+  const editingUser = ref<Record<string, unknown> | null>(null)
+  const deletingUser = ref<{ id: string; displayName: string } | null>(null)
+  const isSubmitting = ref(false)
+  const isDeleting = ref(false)
+  const deleteError = ref('')
+
+  const toast = useToast()
+
+  const userSchema = z.object({
+    legalFirstName: z.string().min(1, 'Legal first name is required'),
+    legalLastName: z.string().min(1, 'Legal last name is required'),
+    preferredFirstName: z.string().optional(),
+    preferredLastName: z.string().optional(),
+    email: z.email('Invalid email address'),
+    role: z.enum(['admin', 'supervisor', 'employee']),
+    status: z.enum(['active', 'on_leave', 'inactive']),
+  })
+
+  type UserFormState = {
+    legalFirstName: string
+    legalLastName: string
+    preferredFirstName: string
+    preferredLastName: string
+    email: string
+    role: 'admin' | 'supervisor' | 'employee'
+    status: 'active' | 'on_leave' | 'inactive'
+  }
+
+  const formState = reactive<UserFormState>({
+    legalFirstName: '',
+    legalLastName: '',
+    preferredFirstName: '',
+    preferredLastName: '',
+    email: '',
+    role: 'employee',
+    status: 'active',
+  })
+
+  function openCreate() {
+    editingUser.value = null
+    Object.assign(formState, {
+      legalFirstName: '',
+      legalLastName: '',
+      preferredFirstName: '',
+      preferredLastName: '',
+      email: '',
+      role: 'employee',
+      status: 'active',
+    })
+    isFormOpen.value = true
+  }
+
+  function openEdit(user: Record<string, unknown>) {
+    editingUser.value = user
+    Object.assign(formState, {
+      legalFirstName: user.legalFirstName || '',
+      legalLastName: user.legalLastName || '',
+      preferredFirstName: user.preferredFirstName || '',
+      preferredLastName: user.preferredLastName || '',
+      email: user.email || '',
+      role: user.role || 'employee',
+      status: user.status || 'active',
+    })
+    isFormOpen.value = true
+  }
+
+  function openDelete(user: { id: string; displayName: string }) {
+    deletingUser.value = user
+    deleteError.value = ''
+    isDeleteOpen.value = true
+  }
+
+  async function submitForm() {
+    isSubmitting.value = true
+    try {
+      if (editingUser.value) {
+        await $fetch(`/api/users/${editingUser.value.id}`, {
+          method: 'PUT',
+          body: {
+            legalFirstName: formState.legalFirstName,
+            legalLastName: formState.legalLastName,
+            preferredFirstName: formState.preferredFirstName || null,
+            preferredLastName: formState.preferredLastName || null,
+            role: formState.role,
+            status: formState.status,
+          },
+        })
+        toast.add({ title: 'User updated', color: 'success' })
+      } else {
+        await $fetch('/api/users', {
+          method: 'POST',
+          body: {
+            legalFirstName: formState.legalFirstName,
+            legalLastName: formState.legalLastName,
+            preferredFirstName: formState.preferredFirstName || null,
+            preferredLastName: formState.preferredLastName || null,
+            email: formState.email,
+            role: formState.role,
+            status: formState.status,
+          },
+        })
+        toast.add({ title: 'User created', color: 'success' })
+      }
+      isFormOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      toast.add({
+        title: fetchErr.data?.statusMessage || 'Failed to save user',
+        color: 'error',
+      })
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deletingUser.value) return
+    isDeleting.value = true
+    deleteError.value = ''
+    try {
+      await $fetch(`/api/users/${deletingUser.value.id}`, { method: 'DELETE' })
+      toast.add({ title: 'User deleted', color: 'success' })
+      isDeleteOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const fetchErr = err as { data?: { statusMessage?: string } }
+      deleteError.value = fetchErr.data?.statusMessage || 'Failed to delete user'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+  const roleColor: Record<string, BadgeColor> = {
+    admin: 'error',
+    supervisor: 'warning',
+    employee: 'info',
+  }
+
+  const statusColor: Record<string, BadgeColor> = {
+    active: 'success',
+    on_leave: 'warning',
+    inactive: 'neutral',
+  }
+
+  const roleOptions = [
+    { label: 'All Roles', value: '' },
+    { label: 'Admin', value: 'admin' },
+    { label: 'Supervisor', value: 'supervisor' },
+    { label: 'Employee', value: 'employee' },
+  ]
+
+  const statusOptions = [
+    { label: 'All Statuses', value: '' },
+    { label: 'Active', value: 'active' },
+    { label: 'On Leave', value: 'on_leave' },
+    { label: 'Inactive', value: 'inactive' },
+  ]
+
+  function getImageLink(user: { image: boolean; id: string }) {
+    return user.image ? `/api/users/${user.id}/profile` : undefined
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Users</h1>
+        <p class="mt-1 text-gray-500 dark:text-gray-400">Manage user accounts and roles.</p>
+      </div>
+      <UButton
+        v-if="isAdmin"
+        color="primary"
+        icon="i-heroicons-plus-20-solid"
+        label="Add User"
+        @click="openCreate"
+      />
+    </div>
+
+    <!-- Filters -->
+    <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center">
+      <UInput
+        v-model="search"
+        placeholder="Search by name or email..."
+        icon="i-heroicons-magnifying-glass-20-solid"
+        class="md:w-64"
+      />
+      <USelect v-model="roleFilter" :items="roleOptions" class="md:w-40" />
+      <USelect v-model="statusFilter" :items="statusOptions" class="md:w-40" />
+    </div>
+
+    <UCard>
+      <div v-if="pending" class="space-y-4">
+        <div v-for="i in 5" :key="i" class="flex items-center gap-3 py-3">
+          <USkeleton class="h-10 w-10 rounded-full" />
+          <div class="w-full space-y-2">
+            <USkeleton class="h-4 w-1/3" />
+            <USkeleton class="h-3 w-1/4" />
+          </div>
+        </div>
+      </div>
+
+      <div v-else-if="error">
+        <UAlert
+          icon="i-heroicons-exclamation-triangle-20-solid"
+          color="error"
+          variant="subtle"
+          title="Error loading users"
+          :description="error.message"
+        />
+      </div>
+
+      <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
+        <NuxtLink
+          v-for="user in users"
+          :key="user.id"
+          :to="`/users/${user.id}`"
+          class="-mx-4 flex items-center justify-between px-4 py-4 transition-colors first:pt-0 last:pb-0 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+        >
+          <div class="flex items-center gap-3">
+            <UAvatar :src="getImageLink(user)" :alt="user.displayName" size="md" />
+            <div>
+              <p class="font-medium text-gray-900 dark:text-white">{{ user.displayName }}</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">{{ user.email }}</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <UBadge :color="roleColor[user.role] || 'neutral'" variant="subtle" size="sm">
+              {{ user.role }}
+            </UBadge>
+            <UBadge :color="statusColor[user.status] || 'neutral'" variant="subtle" size="sm">
+              {{ user.status.replace('_', ' ') }}
+            </UBadge>
+            <div v-if="isAdmin" class="ml-2 flex gap-1" @click.prevent>
+              <UButton
+                color="neutral"
+                variant="ghost"
+                icon="i-heroicons-pencil-square-20-solid"
+                size="sm"
+                @click="openEdit(user)"
+              />
+              <UButton
+                color="error"
+                variant="ghost"
+                icon="i-heroicons-trash-20-solid"
+                size="sm"
+                @click="openDelete(user)"
+              />
+            </div>
+          </div>
+        </NuxtLink>
+
+        <div v-if="users?.length === 0" class="py-8 text-center text-gray-500">No users found.</div>
+      </div>
+    </UCard>
+
+    <!-- Create/Edit Modal -->
+    <UModal v-model:open="isFormOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+            {{ editingUser ? 'Edit User' : 'Add User' }}
+          </h3>
+          <UForm :schema="userSchema" :state="formState" class="space-y-4" @submit="submitForm">
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Legal First Name" name="legalFirstName" required>
+                <UInput v-model="formState.legalFirstName" class="w-full" />
+              </UFormField>
+              <UFormField label="Legal Last Name" name="legalLastName" required>
+                <UInput v-model="formState.legalLastName" class="w-full" />
+              </UFormField>
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Preferred First Name" name="preferredFirstName">
+                <UInput v-model="formState.preferredFirstName" class="w-full" />
+              </UFormField>
+              <UFormField label="Preferred Last Name" name="preferredLastName">
+                <UInput v-model="formState.preferredLastName" class="w-full" />
+              </UFormField>
+            </div>
+            <UFormField v-if="!editingUser" label="Email" name="email" required>
+              <UInput v-model="formState.email" type="email" class="w-full" />
+            </UFormField>
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Role" name="role" required>
+                <USelect
+                  v-model="formState.role"
+                  :items="[
+                    { label: 'Admin', value: 'admin' },
+                    { label: 'Supervisor', value: 'supervisor' },
+                    { label: 'Employee', value: 'employee' },
+                  ]"
+                  class="w-full"
+                />
+              </UFormField>
+              <UFormField label="Status" name="status" required>
+                <USelect
+                  v-model="formState.status"
+                  :items="[
+                    { label: 'Active', value: 'active' },
+                    { label: 'On Leave', value: 'on_leave' },
+                    { label: 'Inactive', value: 'inactive' },
+                  ]"
+                  class="w-full"
+                />
+              </UFormField>
+            </div>
+            <div class="flex justify-end gap-2 pt-2">
+              <UButton variant="soft" color="neutral" @click="isFormOpen = false">Cancel</UButton>
+              <UButton type="submit" :loading="isSubmitting">
+                {{ editingUser ? 'Save' : 'Create' }}
+              </UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Delete Confirmation Modal -->
+    <UModal v-model:open="isDeleteOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Delete User</h3>
+          <p class="mb-4 text-gray-500 dark:text-gray-400">
+            Are you sure you want to delete <strong>{{ deletingUser?.displayName }}</strong
+            >? This action cannot be undone.
+          </p>
+          <UAlert
+            v-if="deleteError"
+            icon="i-heroicons-exclamation-triangle-20-solid"
+            color="error"
+            variant="subtle"
+            :title="deleteError"
+            class="mb-4"
+          />
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isDeleteOpen = false">Cancel</UButton>
+            <UButton color="error" :loading="isDeleting" @click="confirmDelete">Delete</UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -33,11 +33,11 @@ function isEmailAllowed(email: string): boolean {
 
 Three roles, stored on the User model:
 
-| Role | Permissions |
-|---|---|
-| **admin** | Full CRUD on locations, items, users. Check in/out items. |
-| **supervisor** | Check in/out items (for self and others). Read all data. |
-| **employee** | Read-only. Can view items, locations, own checkout history. Cannot perform check-in/out. |
+| Role           | Permissions                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| **admin**      | Full CRUD on locations, items, users. Check in/out items.                                |
+| **supervisor** | Check in/out items (for self and others). Read all data.                                 |
+| **employee**   | Read-only. Can view items, locations, own checkout history. Cannot perform check-in/out. |
 
 ### Where roles are enforced
 
@@ -47,11 +47,11 @@ Three roles, stored on the User model:
 
 ## User Status & Login
 
-| Status | Can log in? | Notes |
-|---|---|---|
-| `active` | Yes | Normal access |
-| `on_leave` | Yes | Can still log in (e.g., to return items), but UI shows indicator |
-| `inactive` | No | Login blocked. Admin must reactivate. |
+| Status     | Can log in? | Notes                                                            |
+| ---------- | ----------- | ---------------------------------------------------------------- |
+| `active`   | Yes         | Normal access                                                    |
+| `on_leave` | Yes         | Can still log in (e.g., to return items), but UI shows indicator |
+| `inactive` | No          | Login blocked. Admin must reactivate.                            |
 
 Inactive users should be blocked at the auth level — either via a Better Auth hook that checks status before completing sign-in, or by checking status in the global middleware and redirecting to an "account inactive" page.
 
@@ -83,7 +83,7 @@ if (!session.value && to.path !== '/auth') {
 ```typescript
 // In auth.vue, after successful signIn
 const route = useRoute()
-const redirectTo = route.query.redirect as string || '/'
+const redirectTo = (route.query.redirect as string) || '/'
 await navigateTo(redirectTo, { external: true })
 ```
 
@@ -91,26 +91,27 @@ await navigateTo(redirectTo, { external: true })
 
 ```typescript
 if (session.value && to.path === '/auth') {
-  const redirect = to.query.redirect as string || '/'
+  const redirect = (to.query.redirect as string) || '/'
   return navigateTo(redirect)
 }
 ```
 
 ## Session Validation (Server-Side)
 
-All API routes validate the session before processing:
+All API routes use the `requireAuth` utility (`server/utils/require-auth.ts`) for authentication and role checking:
 
 ```typescript
-const session = await auth.api.getSession({ headers: event.headers })
+// Authentication only (any logged-in user)
+const session = await requireAuth(event)
 
-if (!session) {
-  throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-}
-
-// For role-restricted endpoints:
-const user = await prisma.user.findUnique({ where: { id: session.user.id } })
-
-if (user.role !== 'admin') {
-  throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
-}
+// Authentication + role check (throws 403 if role doesn't match)
+const session = await requireAuth(event, ['admin'])
+const session = await requireAuth(event, ['admin', 'supervisor'])
 ```
+
+`requireAuth` returns the session object (with `user` and `session` properties) or throws:
+
+- **401 Unauthorized** — no valid session
+- **403 Forbidden** — session exists but user's role is not in the allowed list
+
+The returned `session.user` includes `id`, `email`, `name`, `role`, and `status` fields.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,13 +23,13 @@ Item 1──* CheckoutLog
 
 ### Location
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| name | String | e.g., "The Warren Center - Central" |
-| address | String? | Optional full address |
-| createdAt | DateTime | Auto-set |
-| updatedAt | DateTime | Auto-updated |
+| Field     | Type          | Notes                               |
+| --------- | ------------- | ----------------------------------- |
+| id        | String (UUID) | Primary key                         |
+| name      | String        | e.g., "The Warren Center - Central" |
+| address   | String?       | Optional full address               |
+| createdAt | DateTime      | Auto-set                            |
+| updatedAt | DateTime      | Auto-updated                        |
 
 ### User (extends Better Auth)
 
@@ -37,53 +37,54 @@ Better Auth provides: `id`, `email`, `emailVerified`, `image`, `createdAt`, `upd
 
 Additional fields:
 
-| Field | Type | Notes |
-|---|---|---|
-| legalFirstName | String | Required |
-| legalLastName | String | Required |
-| preferredFirstName | String? | Optional, displayed when present |
-| preferredLastName | String? | Optional, displayed when present |
-| role | String | `admin`, `supervisor`, or `employee` |
-| status | String | `active`, `on_leave`, or `inactive` |
+| Field              | Type    | Notes                                                                            |
+| ------------------ | ------- | -------------------------------------------------------------------------------- |
+| legalFirstName     | String? | Nullable in DB (for Better Auth-created users), required by API on create/update |
+| legalLastName      | String? | Nullable in DB, required by API on create/update                                 |
+| preferredFirstName | String? | Optional, displayed when present                                                 |
+| preferredLastName  | String? | Optional, displayed when present                                                 |
+| role               | String  | `admin`, `supervisor`, or `employee` (default: `employee`)                       |
+| status             | String  | `active`, `on_leave`, or `inactive` (default: `active`)                          |
 
 The existing `name` field from Better Auth can be computed as the display name (preferred name if set, otherwise legal name).
 
 **Display name logic:**
+
 - First name: `preferredFirstName ?? legalFirstName`
 - Last name: `preferredLastName ?? legalLastName`
 
 ### Item
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| name | String | Human-readable item name |
-| description | String? | Optional details |
-| condition | String | `good`, `fair`, `damaged`, or `retired` |
-| status | String | `available` or `checked_out` |
-| homeLocationId | String (FK) | Location where item was originally assigned |
-| currentLocationId | String (FK) | Location where item currently resides (updates on check-in) |
-| qrCodeUrl | String | Stored path/data for the generated QR code |
-| createdAt | DateTime | Auto-set |
-| updatedAt | DateTime | Auto-updated |
+| Field             | Type          | Notes                                                       |
+| ----------------- | ------------- | ----------------------------------------------------------- |
+| id                | String (UUID) | Primary key                                                 |
+| name              | String        | Human-readable item name                                    |
+| description       | String?       | Optional details                                            |
+| condition         | String        | `good`, `fair`, `damaged`, or `retired`                     |
+| status            | String        | `available` or `checked_out`                                |
+| homeLocationId    | String (FK)   | Location where item was originally assigned                 |
+| currentLocationId | String (FK)   | Location where item currently resides (updates on check-in) |
+| qrCodeUrl         | String        | Stored path/data for the generated QR code                  |
+| createdAt         | DateTime      | Auto-set                                                    |
+| updatedAt         | DateTime      | Auto-updated                                                |
 
 ### CheckoutLog
 
 The audit trail. Each checkout creates a row. Check-in completes that row.
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| itemId | String (FK) | The item being checked in/out |
-| userId | String (FK) | The person who has/had the item |
-| checkedOutBy | String (FK → User) | Admin/supervisor who performed checkout |
-| checkedOutFromLocationId | String (FK → Location) | Where the item was when checked out |
-| checkedOutAt | DateTime | When checkout occurred |
-| checkedInBy | String? (FK → User) | Admin/supervisor who performed check-in (null until returned) |
-| checkedInAtLocationId | String? (FK → Location) | Where the item was returned (null until returned) |
-| checkedInAt | DateTime? | When check-in occurred (null until returned) |
-| conditionOnReturn | String? | `good`, `fair`, `damaged`, or `retired` (null until returned) |
-| createdAt | DateTime | Auto-set |
+| Field                    | Type                    | Notes                                                         |
+| ------------------------ | ----------------------- | ------------------------------------------------------------- |
+| id                       | String (UUID)           | Primary key                                                   |
+| itemId                   | String (FK)             | The item being checked in/out                                 |
+| userId                   | String (FK)             | The person who has/had the item                               |
+| checkedOutBy             | String (FK → User)      | Admin/supervisor who performed checkout                       |
+| checkedOutFromLocationId | String (FK → Location)  | Where the item was when checked out                           |
+| checkedOutAt             | DateTime                | When checkout occurred                                        |
+| checkedInBy              | String? (FK → User)     | Admin/supervisor who performed check-in (null until returned) |
+| checkedInAtLocationId    | String? (FK → Location) | Where the item was returned (null until returned)             |
+| checkedInAt              | DateTime?               | When check-in occurred (null until returned)                  |
+| conditionOnReturn        | String?                 | `good`, `fair`, `damaged`, or `retired` (null until returned) |
+| createdAt                | DateTime                | Auto-set                                                      |
 
 ### Session, Account, Verification
 
@@ -91,12 +92,12 @@ These are Better Auth's default models — unchanged from the existing schema. S
 
 ## Enums (stored as strings)
 
-| Enum | Values |
-|---|---|
-| Role | `admin`, `supervisor`, `employee` |
-| UserStatus | `active`, `on_leave`, `inactive` |
+| Enum          | Values                               |
+| ------------- | ------------------------------------ |
+| Role          | `admin`, `supervisor`, `employee`    |
+| UserStatus    | `active`, `on_leave`, `inactive`     |
 | ItemCondition | `good`, `fair`, `damaged`, `retired` |
-| ItemStatus | `available`, `checked_out` |
+| ItemStatus    | `available`, `checked_out`           |
 
 All enum transitions are allowed (e.g., an item can go from `retired` back to `good`, a user can move between any status).
 

--- a/docs/features/users.md
+++ b/docs/features/users.md
@@ -12,14 +12,15 @@ See [data-model.md](../data-model.md) for the full `User` schema.
 
 Four name fields are stored:
 
-| Field | Required | Notes |
-|---|---|---|
-| legalFirstName | Yes | From roster "Legal Name" column (parsed) |
-| legalLastName | Yes | From roster "Legal Name" column (parsed) |
-| preferredFirstName | No | From roster "Preferred or Chosen First Name" column |
-| preferredLastName | No | From roster "Preferred or Chosen Last Name" column |
+| Field              | Required | Notes                                               |
+| ------------------ | -------- | --------------------------------------------------- |
+| legalFirstName     | Yes      | From roster "Legal Name" column (parsed)            |
+| legalLastName      | Yes      | From roster "Legal Name" column (parsed)            |
+| preferredFirstName | No       | From roster "Preferred or Chosen First Name" column |
+| preferredLastName  | No       | From roster "Preferred or Chosen Last Name" column  |
 
 **Display name logic**: Use preferred name when available, fall back to legal name.
+
 - Display first: `preferredFirstName ?? legalFirstName`
 - Display last: `preferredLastName ?? legalLastName`
 
@@ -27,33 +28,33 @@ Better Auth's `name` field is set to the computed display name: `"${displayFirst
 
 ### Roles
 
-| Role | Description |
-|---|---|
-| `admin` | Full access. CRUD everything. Check in/out. |
-| `supervisor` | Check in/out items. Read all data. |
-| `employee` | Read-only. Items checked in/out *for* them. |
+| Role         | Description                                 |
+| ------------ | ------------------------------------------- |
+| `admin`      | Full access. CRUD everything. Check in/out. |
+| `supervisor` | Check in/out items. Read all data.          |
+| `employee`   | Read-only. Items checked in/out _for_ them. |
 
 ### Statuses
 
-| Status | Can log in? | Description |
-|---|---|---|
-| `active` | Yes | Normal access |
-| `on_leave` | Yes | Can log in (e.g., to return items). UI shows indicator. |
-| `inactive` | No | Blocked from login. Must be reactivated by admin. |
+| Status     | Can log in? | Description                                             |
+| ---------- | ----------- | ------------------------------------------------------- |
+| `active`   | Yes         | Normal access                                           |
+| `on_leave` | Yes         | Can log in (e.g., to return items). UI shows indicator. |
+| `inactive` | No          | Blocked from login. Must be reactivated by admin.       |
 
 All status transitions are allowed (admin can move a user between any status).
 
 ## Permissions
 
-| Action | Admin | Supervisor | Employee |
-|---|---|---|---|
-| View user list | Yes | Yes | No |
-| View user detail | Yes | Yes | Own profile only |
-| Create user | Yes | No | No |
-| Edit user | Yes | No | No |
-| Delete user | Yes | No | No |
-| Change user role | Yes | No | No |
-| Change user status | Yes | No | No |
+| Action             | Admin | Supervisor | Employee         |
+| ------------------ | ----- | ---------- | ---------------- |
+| View user list     | Yes   | Yes        | No               |
+| View user detail   | Yes   | Yes        | Own profile only |
+| Create user        | Yes   | No         | No               |
+| Edit user          | Yes   | No         | No               |
+| Delete user        | Yes   | No         | No               |
+| Change user role   | Yes   | No         | No               |
+| Change user status | Yes   | No         | No               |
 
 ## Admin User Management
 
@@ -71,6 +72,7 @@ All status transitions are allowed (admin can move a user between any status).
 **Route**: `/users/[id]`
 
 Displays:
+
 - Legal name and preferred name (if different)
 - Email, role, status
 - Profile picture (existing feature)
@@ -80,6 +82,7 @@ Displays:
 ### Create User Form
 
 Fields:
+
 - Legal first name (required)
 - Legal last name (required)
 - Preferred first name (optional)
@@ -99,18 +102,33 @@ Deleting a user with open checkouts should be blocked — items must be checked 
 ## Employee Self-Service
 
 Employees can view their own profile at `/profile` or `/users/me`:
+
 - See their name, email, role, status
 - See their checkout history (what they currently have, what they've returned)
 - Upload/change profile picture (existing feature)
 
+## Implementation Notes
+
+### Display Name Utility
+
+The `getDisplayName` function (`server/utils/display-name.ts`) computes the display name from user name fields. It is auto-imported by Nitro in all server routes.
+
+### Dashboard
+
+The dashboard (`/`) serves as a navigation hub with role-aware cards linking to Profile, Users (admin/supervisor only), and Locations.
+
+### Profile Page
+
+The profile page lives at `/profile` and uses `GET /api/users/me` to fetch the current user's data. It includes profile photo upload (moved from the old dashboard) and logout functionality.
+
 ## API Routes
 
-| Method | Route | Description | Role |
-|---|---|---|---|
-| GET | `/api/users` | List all users | Admin, Supervisor |
-| GET | `/api/users/[id]` | Get user detail | Admin, Supervisor, or own profile |
-| POST | `/api/users` | Create user | Admin |
-| PUT | `/api/users/[id]` | Update user | Admin |
-| DELETE | `/api/users/[id]` | Delete user (blocked if open checkouts) | Admin |
-| GET | `/api/users/me` | Get current user's profile | All |
-| GET | `/api/users/[id]/history` | User's checkout history | Admin, Supervisor, or own history |
+| Method | Route                     | Description                                         | Role                              |
+| ------ | ------------------------- | --------------------------------------------------- | --------------------------------- |
+| GET    | `/api/users`              | List all users (filterable by role, status, search) | Admin, Supervisor                 |
+| GET    | `/api/users/[id]`         | Get user detail with checkout stats                 | Admin, Supervisor, or own profile |
+| POST   | `/api/users`              | Create user (validates email domain)                | Admin                             |
+| PUT    | `/api/users/[id]`         | Update user (recomputes display name)               | Admin                             |
+| DELETE | `/api/users/[id]`         | Delete user (blocked if open checkouts)             | Admin                             |
+| GET    | `/api/users/me`           | Get current user's profile                          | All                               |
+| GET    | `/api/users/[id]/history` | User's checkout history (last 50 entries)           | Admin, Supervisor, or own history |

--- a/server/api/users/[id]/history.get.ts
+++ b/server/api/users/[id]/history.get.ts
@@ -1,0 +1,31 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireAuth(event)
+  const id = getRouterParam(event, 'id')
+
+  const userRole = session.user.role
+  const isOwnProfile = session.user.id === id
+  if (!isOwnProfile && userRole !== 'admin' && userRole !== 'supervisor') {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const logs = await prisma.checkoutLog.findMany({
+    where: { userId: id },
+    include: {
+      item: { select: { id: true, name: true } },
+      checkedOutFromLocation: { select: { id: true, name: true } },
+      checkedInAtLocation: { select: { id: true, name: true } },
+    },
+    orderBy: { checkedOutAt: 'desc' },
+    take: 50,
+  })
+
+  return logs.map((log) => ({
+    id: log.id,
+    item: log.item,
+    checkedOutAt: log.checkedOutAt,
+    checkedOutFromLocation: log.checkedOutFromLocation,
+    checkedInAt: log.checkedInAt,
+    checkedInAtLocation: log.checkedInAtLocation,
+    conditionOnReturn: log.conditionOnReturn,
+  }))
+})

--- a/server/api/users/[id]/index.delete.ts
+++ b/server/api/users/[id]/index.delete.ts
@@ -1,0 +1,33 @@
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const id = getRouterParam(event, 'id')
+
+  const existing = await prisma.user.findUnique({
+    where: { id },
+    include: {
+      _count: {
+        select: {
+          itemsHeld: { where: { checkedInAt: null } },
+        },
+      },
+    },
+  })
+
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  const openCheckouts = existing._count.itemsHeld
+  if (openCheckouts > 0) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Cannot delete user: they have ${openCheckouts} items currently checked out.`,
+    })
+  }
+
+  await prisma.user.delete({ where: { id } })
+
+  setResponseStatus(event, 204)
+  return null
+})

--- a/server/api/users/[id]/index.get.ts
+++ b/server/api/users/[id]/index.get.ts
@@ -1,0 +1,59 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireAuth(event)
+  const id = getRouterParam(event, 'id')
+
+  const userRole = session.user.role
+  const isOwnProfile = session.user.id === id
+  if (!isOwnProfile && userRole !== 'admin' && userRole !== 'supervisor') {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      legalFirstName: true,
+      legalLastName: true,
+      preferredFirstName: true,
+      preferredLastName: true,
+      role: true,
+      status: true,
+      image: true,
+      emailVerified: true,
+      createdAt: true,
+      _count: {
+        select: {
+          itemsHeld: { where: { checkedInAt: null } },
+        },
+      },
+    },
+  })
+
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  const pastCheckouts = await prisma.checkoutLog.count({
+    where: { userId: id, checkedInAt: { not: null } },
+  })
+
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    legalFirstName: user.legalFirstName,
+    legalLastName: user.legalLastName,
+    preferredFirstName: user.preferredFirstName,
+    preferredLastName: user.preferredLastName,
+    displayName: getDisplayName(user),
+    role: user.role,
+    status: user.status,
+    image: user.image != null,
+    emailVerified: user.emailVerified,
+    createdAt: user.createdAt,
+    currentItemsHeld: user._count.itemsHeld,
+    pastCheckoutCount: pastCheckouts,
+  }
+})

--- a/server/api/users/[id]/index.put.ts
+++ b/server/api/users/[id]/index.put.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod/v4'
+
+const updateUserSchema = z.object({
+  legalFirstName: z.string().min(1).optional(),
+  legalLastName: z.string().min(1).optional(),
+  preferredFirstName: z.string().nullable().optional(),
+  preferredLastName: z.string().nullable().optional(),
+  role: z.enum(['admin', 'supervisor', 'employee']).optional(),
+  status: z.enum(['active', 'on_leave', 'inactive']).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const result = updateUserSchema.safeParse(body)
+
+  if (!result.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation error',
+      data: result.error.issues,
+    })
+  }
+
+  const existing = await prisma.user.findUnique({ where: { id } })
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  const data: Record<string, unknown> = { ...result.data }
+
+  // Recompute display name if name fields changed
+  const legalFirst = result.data.legalFirstName ?? existing.legalFirstName
+  const legalLast = result.data.legalLastName ?? existing.legalLastName
+  const prefFirst =
+    result.data.preferredFirstName !== undefined
+      ? result.data.preferredFirstName
+      : existing.preferredFirstName
+  const prefLast =
+    result.data.preferredLastName !== undefined
+      ? result.data.preferredLastName
+      : existing.preferredLastName
+  data.name = `${prefFirst || legalFirst} ${prefLast || legalLast}`
+
+  const user = await prisma.user.update({
+    where: { id },
+    data,
+  })
+
+  return user
+})

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,28 +1,57 @@
 export default defineEventHandler(async (event) => {
-  const session = await auth.api.getSession({
-    headers: event.headers,
-  })
+  const session = await requireAuth(event, ['admin', 'supervisor'])
 
-  if (!session) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  const query = getQuery(event)
+  const role = query.role as string | undefined
+  const status = query.status as string | undefined
+  const search = query.search as string | undefined
+
+  const where: Record<string, unknown> = {}
+
+  if (role) {
+    where.role = role
+  }
+  if (status) {
+    where.status = status
+  }
+  if (search) {
+    where.OR = [
+      { legalFirstName: { contains: search } },
+      { legalLastName: { contains: search } },
+      { preferredFirstName: { contains: search } },
+      { preferredLastName: { contains: search } },
+      { email: { contains: search } },
+      { name: { contains: search } },
+    ]
   }
 
   const users = await prisma.user.findMany({
+    where,
     select: {
       id: true,
       email: true,
       name: true,
-      emailVerified: true,
+      legalFirstName: true,
+      legalLastName: true,
+      preferredFirstName: true,
+      preferredLastName: true,
+      role: true,
+      status: true,
       image: true,
     },
+    orderBy: { name: 'asc' },
   })
 
-  const redacted = users.map((user) => {
-    return {
-      ...user,
-      image: user.image != null,
-    }
-  })
-
-  return redacted
+  return users.map((user) => ({
+    id: user.id,
+    legalFirstName: user.legalFirstName,
+    legalLastName: user.legalLastName,
+    preferredFirstName: user.preferredFirstName,
+    preferredLastName: user.preferredLastName,
+    displayName: getDisplayName(user),
+    email: user.email,
+    role: user.role,
+    status: user.status,
+    image: user.image != null,
+  }))
 })

--- a/server/api/users/index.post.ts
+++ b/server/api/users/index.post.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod/v4'
+import { isEmailAllowed } from '~~/server/utils/auth'
+
+const createUserSchema = z.object({
+  legalFirstName: z.string().min(1, 'Legal first name is required'),
+  legalLastName: z.string().min(1, 'Legal last name is required'),
+  preferredFirstName: z.string().nullable().optional(),
+  preferredLastName: z.string().nullable().optional(),
+  email: z.email('Invalid email address'),
+  role: z.enum(['admin', 'supervisor', 'employee']),
+  status: z.enum(['active', 'on_leave', 'inactive']),
+})
+
+export default defineEventHandler(async (event) => {
+  await requireAuth(event, ['admin'])
+
+  const body = await readBody(event)
+  const result = createUserSchema.safeParse(body)
+
+  if (!result.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation error',
+      data: result.error.issues,
+    })
+  }
+
+  if (!isEmailAllowed(result.data.email)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Email domain not allowed',
+    })
+  }
+
+  const existing = await prisma.user.findUnique({ where: { email: result.data.email } })
+  if (existing) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'A user with this email already exists',
+    })
+  }
+
+  const displayName = `${result.data.preferredFirstName || result.data.legalFirstName} ${result.data.preferredLastName || result.data.legalLastName}`
+
+  const user = await prisma.user.create({
+    data: {
+      name: displayName,
+      email: result.data.email,
+      legalFirstName: result.data.legalFirstName,
+      legalLastName: result.data.legalLastName,
+      preferredFirstName: result.data.preferredFirstName ?? null,
+      preferredLastName: result.data.preferredLastName ?? null,
+      role: result.data.role,
+      status: result.data.status,
+    },
+  })
+
+  setResponseStatus(event, 201)
+  return user
+})

--- a/server/api/users/me.get.ts
+++ b/server/api/users/me.get.ts
@@ -1,0 +1,31 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireAuth(event)
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      legalFirstName: true,
+      legalLastName: true,
+      preferredFirstName: true,
+      preferredLastName: true,
+      role: true,
+      status: true,
+      image: true,
+      emailVerified: true,
+      createdAt: true,
+    },
+  })
+
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  return {
+    ...user,
+    displayName: getDisplayName(user),
+    image: user.image != null,
+  }
+})

--- a/server/api/users/upload.post.ts
+++ b/server/api/users/upload.post.ts
@@ -25,7 +25,10 @@ export default defineEventHandler(async (event) => {
   }
 
   if (!file.type || !ALLOWED_MIME_TYPES.includes(file.type)) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid file type. Only PNG, JPEG, GIF, and WebP are allowed.' })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid file type. Only PNG, JPEG, GIF, and WebP are allowed.',
+    })
   }
 
   const uploadRoot = process.env.UPLOAD_STORAGE_PATH

--- a/server/utils/display-name.ts
+++ b/server/utils/display-name.ts
@@ -1,0 +1,12 @@
+interface UserWithNames {
+  legalFirstName: string | null
+  legalLastName: string | null
+  preferredFirstName: string | null
+  preferredLastName: string | null
+}
+
+export function getDisplayName(user: UserWithNames): string {
+  const first = user.preferredFirstName || user.legalFirstName || ''
+  const last = user.preferredLastName || user.legalLastName || ''
+  return `${first} ${last}`.trim()
+}

--- a/server/utils/require-auth.ts
+++ b/server/utils/require-auth.ts
@@ -1,0 +1,38 @@
+import type { H3Event } from 'h3'
+import { auth } from './auth'
+
+type Role = 'admin' | 'supervisor' | 'employee'
+
+interface AuthSession {
+  user: {
+    id: string
+    email: string
+    name: string
+    role: string
+    status: string
+    [key: string]: unknown
+  }
+  session: {
+    id: string
+    [key: string]: unknown
+  }
+}
+
+export async function requireAuth(event: H3Event, roles?: Role[]): Promise<AuthSession> {
+  const session = await auth.api.getSession({
+    headers: event.headers,
+  })
+
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  if (roles && roles.length > 0) {
+    const userRole = (session.user as Record<string, unknown>).role as string
+    if (!roles.includes(userRole as Role)) {
+      throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+    }
+  }
+
+  return session as unknown as AuthSession
+}


### PR DESCRIPTION
## Summary
- Full CRUD API for users (`GET/POST/PUT/DELETE /api/users`, `GET /api/users/me`, `GET /api/users/[id]/history`) with role-based access control (admin-only mutations, admin/supervisor for list, own-profile access for detail/history)
- User list page (`/users`) with search, role/status filters, admin create/edit modals, and delete confirmation with open-checkout protection
- User detail page (`/users/[id]`) showing profile info, preferred vs legal names, checkout stats, and history
- Profile page (`/profile`) with photo upload, logout, and own checkout history — replaces old dashboard user list
- Refactored dashboard (`/`) into a navigation hub with role-aware cards
- Updated app header with "TWC Inventory" branding, Locations/Users nav links, and Profile link
- Added `requireAuth` server utility and `getDisplayName` helper

## Test plan
- [ ] Verify `GET /api/users` returns filtered user list (admin/supervisor only, employees get 403)
- [ ] Verify `GET /api/users/me` returns current user profile for all roles
- [ ] Verify `GET /api/users/[id]` respects access: admin, supervisor, or own profile only
- [ ] Verify `POST /api/users` creates a user with domain validation (admin only)
- [ ] Verify `PUT /api/users/[id]` updates user and recomputes display name (admin only)
- [ ] Verify `DELETE /api/users/[id]` blocks deletion when user has open checkouts (409)
- [ ] Verify `/users` page redirects employees, shows read-only for supervisors, full CRUD for admins
- [ ] Verify `/profile` page works for all roles with photo upload and logout
- [ ] Verify checkout history displays correctly on user detail and profile pages

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)