### PR TITLE
Location management: API routes and admin UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,22 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow) and `/` (dashboard with user list + profile picture upload)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/locations` (location list), `/locations/[id]` (location detail)
 
 ### Backend (`server/`)
 
 - **Auth handler**: `server/api/auth/[...all].ts` — catch-all route delegating to Better Auth
 - **Auth config**: `server/utils/auth.ts` — Better Auth setup with Prisma adapter (SQLite) and emailOTP plugin using Nodemailer (Gmail SMTP)
+- **Auth middleware**: `server/middleware/auth.ts` — attaches session to `event.context.session` for all `/api/*` routes (skips `/api/auth/*`)
+- **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
-- **API routes**: `server/api/users/` — user listing, profile image serving, and file upload (multipart form)
+- **API routes**: `server/api/users/` (user listing, profile pictures), `server/api/locations/` (location CRUD with soft delete)
 
 ### Database (`prisma/`)
 
 - **SQLite** via `better-sqlite3` driver adapter (not the default Prisma SQLite driver)
 - **Prisma client output**: `prisma/generated/` (custom output path)
-- **Schema models**: User, Session, Account, Verification (Better Auth tables)
+- **Schema models**: User, Session, Account, Verification (Better Auth tables), Location, Item, CheckoutLog
 - **Seed**: `prisma/seed.ts` run via `tsx`
 - **Config**: `prisma.config.ts` at project root
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   const colorMode = useColorMode()
+  const route = useRoute()
 
   const isDark = computed({
     get() {
@@ -9,6 +10,24 @@
       colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
     },
   })
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const isLoggedIn = computed(() => !!session.value)
+  const _isAdmin = computed(() => session.value?.user?.role === 'admin')
+
+  const navLinks = computed(() => {
+    if (!isLoggedIn.value) return []
+    const links = [
+      { to: '/', label: 'Dashboard', icon: 'i-heroicons-home-20-solid' },
+      { to: '/locations', label: 'Locations', icon: 'i-heroicons-map-pin-20-solid' },
+    ]
+    return links
+  })
+
+  function isActive(path: string) {
+    if (path === '/') return route.path === '/'
+    return route.path.startsWith(path)
+  }
 </script>
 
 <template>
@@ -20,10 +39,29 @@
         class="sticky top-0 z-50 border-b border-gray-200 bg-white/75 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/75"
       >
         <UContainer class="flex h-16 items-center justify-between">
-          <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
-            <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
-            <span>Nuxt Template</span>
-          </NuxtLink>
+          <div class="flex items-center gap-6">
+            <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
+              <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
+              <span>TWC Inventory</span>
+            </NuxtLink>
+
+            <nav v-if="isLoggedIn" class="hidden items-center gap-1 md:flex">
+              <NuxtLink
+                v-for="link in navLinks"
+                :key="link.to"
+                :to="link.to"
+                class="flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors"
+                :class="
+                  isActive(link.to)
+                    ? 'bg-primary-50 text-primary-600 dark:bg-primary-950 dark:text-primary-400'
+                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'
+                "
+              >
+                <UIcon :name="link.icon" class="h-4 w-4" />
+                {{ link.label }}
+              </NuxtLink>
+            </nav>
+          </div>
 
           <div class="flex items-center gap-2">
             <UButton

--- a/app/pages/locations/[id].vue
+++ b/app/pages/locations/[id].vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+  import { z } from 'zod'
+  import type { FormSubmitEvent } from '@nuxt/ui'
+
+  const route = useRoute()
+  const toast = useToast()
+  const id = route.params.id as string
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const isAdmin = computed(() => session.value?.user?.role === 'admin')
+
+  const { data: location, pending, error, refresh } = await useFetch(`/api/locations/${id}`)
+
+  // Edit modal
+  const isEditOpen = ref(false)
+  const locationSchema = z.object({
+    name: z.string().min(1, 'Name is required').max(200),
+    address: z.string().max(500).optional(),
+  })
+  const formState = reactive({ name: '', address: '' })
+
+  function openEdit() {
+    if (!location.value) return
+    formState.name = location.value.name
+    formState.address = location.value.address ?? ''
+    isEditOpen.value = true
+  }
+
+  async function handleEdit(_event: FormSubmitEvent<Record<string, unknown>>) {
+    try {
+      await $fetch(`/api/locations/${id}`, {
+        method: 'PUT',
+        body: { name: formState.name, address: formState.address || undefined },
+      })
+      toast.add({ title: 'Location updated', color: 'success' })
+      isEditOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : 'Something went wrong'
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    }
+  }
+
+  async function toggleStatus() {
+    if (!location.value) return
+    const newStatus = location.value.status === 'active' ? 'inactive' : 'active'
+    const action = newStatus === 'inactive' ? 'deactivate' : 'reactivate'
+    try {
+      await $fetch(`/api/locations/${id}`, {
+        method: 'PUT',
+        body: { status: newStatus },
+      })
+      toast.add({ title: `Location ${action}d`, color: 'success' })
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : `Failed to ${action} location`
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    }
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <!-- Back link -->
+    <NuxtLink
+      to="/locations"
+      class="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+    >
+      <UIcon name="i-heroicons-arrow-left-20-solid" class="h-4 w-4" />
+      Back to locations
+    </NuxtLink>
+
+    <!-- Loading -->
+    <UCard v-if="pending">
+      <div class="space-y-3">
+        <USkeleton class="h-6 w-1/3" />
+        <USkeleton class="h-4 w-1/2" />
+      </div>
+    </UCard>
+
+    <!-- Error / Not found -->
+    <UAlert
+      v-else-if="error"
+      icon="i-heroicons-exclamation-triangle-20-solid"
+      color="error"
+      variant="subtle"
+      title="Location not found"
+      description="This location does not exist or you don't have access to it."
+    />
+
+    <!-- Location detail -->
+    <template v-else-if="location">
+      <!-- Inactive banner -->
+      <UAlert
+        v-if="location.status === 'inactive'"
+        class="mb-4"
+        icon="i-heroicons-archive-box-20-solid"
+        color="warning"
+        variant="subtle"
+        title="This location is inactive"
+        description="It won't appear in location lists or dropdowns for non-admin users."
+      />
+
+      <UCard>
+        <template #header>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+                {{ location.name }}
+              </h1>
+              <UBadge
+                :color="location.status === 'active' ? 'success' : 'neutral'"
+                variant="subtle"
+                size="sm"
+              >
+                {{ location.status }}
+              </UBadge>
+            </div>
+            <div v-if="isAdmin" class="flex items-center gap-2">
+              <UButton
+                variant="soft"
+                color="neutral"
+                icon="i-heroicons-pencil-square-20-solid"
+                label="Edit"
+                size="sm"
+                @click="openEdit"
+              />
+              <UButton
+                variant="soft"
+                :color="location.status === 'active' ? 'error' : 'success'"
+                :label="location.status === 'active' ? 'Deactivate' : 'Reactivate'"
+                size="sm"
+                @click="toggleStatus"
+              />
+            </div>
+          </div>
+        </template>
+
+        <div class="space-y-4">
+          <div v-if="location.address">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Address</p>
+            <p class="text-gray-900 dark:text-white">{{ location.address }}</p>
+          </div>
+
+          <div class="flex gap-4">
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Home Items</p>
+              <p class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ location.homeItemCount }}
+              </p>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Items Here Now</p>
+              <p class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ location.currentItemCount }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </UCard>
+
+      <!-- Current items -->
+      <UCard class="mt-6">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-cube-20-solid" class="h-5 w-5 text-gray-500" />
+            <h2 class="text-base font-semibold text-gray-900 dark:text-white">
+              Items at This Location
+            </h2>
+            <UBadge variant="subtle" color="primary" size="xs">
+              {{ location.currentItems?.length ?? 0 }}
+            </UBadge>
+          </div>
+        </template>
+
+        <div v-if="!location.currentItems?.length" class="py-6 text-center text-gray-500">
+          No items currently at this location.
+        </div>
+
+        <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
+          <div
+            v-for="item in location.currentItems"
+            :key="item.id"
+            class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+          >
+            <div>
+              <p class="font-medium text-gray-900 dark:text-white">{{ item.name }}</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <UBadge
+                :color="
+                  item.condition === 'good'
+                    ? 'success'
+                    : item.condition === 'fair'
+                      ? 'warning'
+                      : item.condition === 'damaged'
+                        ? 'error'
+                        : 'neutral'
+                "
+                variant="subtle"
+                size="xs"
+              >
+                {{ item.condition }}
+              </UBadge>
+              <UBadge
+                :color="item.status === 'available' ? 'success' : 'warning'"
+                variant="subtle"
+                size="xs"
+              >
+                {{ item.status === 'checked_out' ? 'checked out' : item.status }}
+              </UBadge>
+            </div>
+          </div>
+        </div>
+      </UCard>
+    </template>
+
+    <!-- Edit Modal -->
+    <UModal v-model:open="isEditOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Edit Location</h3>
+          <UForm :schema="locationSchema" :state="formState" class="space-y-4" @submit="handleEdit">
+            <UFormField label="Name" name="name" required>
+              <UInput v-model="formState.name" class="w-full" placeholder="Location name" />
+            </UFormField>
+            <UFormField label="Address" name="address">
+              <UInput
+                v-model="formState.address"
+                class="w-full"
+                placeholder="Street address (optional)"
+              />
+            </UFormField>
+            <div class="flex justify-end gap-2">
+              <UButton variant="soft" color="neutral" @click="isEditOpen = false">Cancel</UButton>
+              <UButton type="submit" color="primary">Save</UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/app/pages/locations/index.vue
+++ b/app/pages/locations/index.vue
@@ -1,0 +1,263 @@
+<script setup lang="ts">
+  import { z } from 'zod'
+  import type { FormSubmitEvent } from '@nuxt/ui'
+
+  const toast = useToast()
+
+  // Auth state
+  const { data: session } = await authClient.useSession(useFetch)
+  const isAdmin = computed(() => session.value?.user?.role === 'admin')
+
+  // Status filter (admin only)
+  const statusFilter = ref<'active' | 'inactive'>('active')
+
+  // Fetch locations
+  const {
+    data: locations,
+    pending,
+    error,
+    refresh,
+  } = await useFetch('/api/locations', {
+    query: computed(() => (isAdmin.value ? { status: statusFilter.value } : {})),
+  })
+
+  // Create/edit modal
+  const isModalOpen = ref(false)
+  const editingLocation = ref<{ id: string; name: string; address: string | null } | null>(null)
+
+  const locationSchema = z.object({
+    name: z.string().min(1, 'Name is required').max(200),
+    address: z.string().max(500).optional(),
+  })
+
+  const formState = reactive({
+    name: '',
+    address: '',
+  })
+
+  function openCreate() {
+    editingLocation.value = null
+    formState.name = ''
+    formState.address = ''
+    isModalOpen.value = true
+  }
+
+  function openEdit(loc: { id: string; name: string; address: string | null }) {
+    editingLocation.value = loc
+    formState.name = loc.name
+    formState.address = loc.address ?? ''
+    isModalOpen.value = true
+  }
+
+  async function handleSubmit(_event: FormSubmitEvent<Record<string, unknown>>) {
+    try {
+      if (editingLocation.value) {
+        await $fetch(`/api/locations/${editingLocation.value.id}`, {
+          method: 'PUT',
+          body: { name: formState.name, address: formState.address || undefined },
+        })
+        toast.add({ title: 'Location updated', color: 'success' })
+      } else {
+        await $fetch('/api/locations', {
+          method: 'POST',
+          body: { name: formState.name, address: formState.address || undefined },
+        })
+        toast.add({ title: 'Location created', color: 'success' })
+      }
+      isModalOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : 'Something went wrong'
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    }
+  }
+
+  // Deactivate / reactivate
+  async function toggleStatus(loc: { id: string; name: string; status: string }) {
+    const newStatus = loc.status === 'active' ? 'inactive' : 'active'
+    const action = newStatus === 'inactive' ? 'deactivate' : 'reactivate'
+    try {
+      await $fetch(`/api/locations/${loc.id}`, {
+        method: 'PUT',
+        body: { status: newStatus },
+      })
+      toast.add({
+        title: `Location ${action}d`,
+        description: loc.name,
+        color: 'success',
+      })
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : `Failed to ${action} location`
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    }
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Locations</h1>
+        <p class="mt-1 text-gray-500 dark:text-gray-400">
+          {{ isAdmin ? 'Manage locations where equipment is stored.' : 'Equipment locations.' }}
+        </p>
+      </div>
+      <div v-if="isAdmin" class="flex items-center gap-3">
+        <UButtonGroup>
+          <UButton
+            :color="statusFilter === 'active' ? 'primary' : 'neutral'"
+            :variant="statusFilter === 'active' ? 'solid' : 'outline'"
+            label="Active"
+            @click="statusFilter = 'active'"
+          />
+          <UButton
+            :color="statusFilter === 'inactive' ? 'primary' : 'neutral'"
+            :variant="statusFilter === 'inactive' ? 'solid' : 'outline'"
+            label="Inactive"
+            @click="statusFilter = 'inactive'"
+          />
+        </UButtonGroup>
+        <UButton
+          color="primary"
+          icon="i-heroicons-plus-20-solid"
+          label="Add Location"
+          @click="openCreate"
+        />
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <UCard v-if="pending">
+      <div class="space-y-4">
+        <div v-for="i in 3" :key="i" class="flex items-center justify-between py-2">
+          <div class="w-full space-y-2">
+            <USkeleton class="h-4 w-1/3" />
+            <USkeleton class="h-3 w-1/2" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Error -->
+    <UAlert
+      v-else-if="error"
+      icon="i-heroicons-exclamation-triangle-20-solid"
+      color="error"
+      variant="subtle"
+      title="Error loading locations"
+      :description="error.message"
+    />
+
+    <!-- Empty state -->
+    <UCard v-else-if="!locations?.length">
+      <div class="py-8 text-center text-gray-500">
+        {{
+          statusFilter === 'inactive'
+            ? 'No inactive locations.'
+            : 'No locations found. Add one to get started.'
+        }}
+      </div>
+    </UCard>
+
+    <!-- Location list -->
+    <div v-else class="space-y-3">
+      <NuxtLink v-for="loc in locations" :key="loc.id" :to="`/locations/${loc.id}`" class="block">
+        <UCard
+          class="transition-shadow hover:shadow-md"
+          :class="{ 'opacity-60': loc.status === 'inactive' }"
+        >
+          <div class="flex items-center justify-between">
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <h3 class="truncate font-semibold text-gray-900 dark:text-white">
+                  {{ loc.name }}
+                </h3>
+                <UBadge
+                  v-if="isAdmin && loc.status === 'inactive'"
+                  color="neutral"
+                  variant="subtle"
+                  size="xs"
+                >
+                  Inactive
+                </UBadge>
+              </div>
+              <p v-if="loc.address" class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">
+                {{ loc.address }}
+              </p>
+              <div class="mt-2 flex gap-3">
+                <UBadge variant="subtle" color="primary" size="xs">
+                  {{ loc.homeItemCount }} home item{{ loc.homeItemCount === 1 ? '' : 's' }}
+                </UBadge>
+                <UBadge variant="subtle" color="success" size="xs">
+                  {{ loc.currentItemCount }} item{{ loc.currentItemCount === 1 ? '' : 's' }} here
+                  now
+                </UBadge>
+              </div>
+            </div>
+            <div v-if="isAdmin" class="ml-4 flex items-center gap-2" @click.prevent>
+              <UButton
+                variant="ghost"
+                color="neutral"
+                icon="i-heroicons-pencil-square-20-solid"
+                size="sm"
+                @click="openEdit(loc)"
+              />
+              <UButton
+                variant="ghost"
+                :color="loc.status === 'active' ? 'error' : 'success'"
+                :icon="
+                  loc.status === 'active'
+                    ? 'i-heroicons-archive-box-20-solid'
+                    : 'i-heroicons-arrow-path-20-solid'
+                "
+                size="sm"
+                @click="toggleStatus(loc)"
+              />
+            </div>
+          </div>
+        </UCard>
+      </NuxtLink>
+    </div>
+
+    <!-- Create/Edit Modal -->
+    <UModal v-model:open="isModalOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+            {{ editingLocation ? 'Edit Location' : 'Add Location' }}
+          </h3>
+          <UForm
+            :schema="locationSchema"
+            :state="formState"
+            class="space-y-4"
+            @submit="handleSubmit"
+          >
+            <UFormField label="Name" name="name" required>
+              <UInput v-model="formState.name" class="w-full" placeholder="Location name" />
+            </UFormField>
+            <UFormField label="Address" name="address">
+              <UInput
+                v-model="formState.address"
+                class="w-full"
+                placeholder="Street address (optional)"
+              />
+            </UFormField>
+            <div class="flex justify-end gap-2">
+              <UButton variant="soft" color="neutral" @click="isModalOpen = false">Cancel</UButton>
+              <UButton type="submit" color="primary">
+                {{ editingLocation ? 'Save' : 'Create' }}
+              </UButton>
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/app/utils/auth-client.ts
+++ b/app/utils/auth-client.ts
@@ -1,6 +1,7 @@
 import { createAuthClient } from 'better-auth/vue'
-import { emailOTPClient } from 'better-auth/client/plugins'
+import { emailOTPClient, inferAdditionalFields } from 'better-auth/client/plugins'
+import type { auth } from '~~/server/utils/auth'
 
 export const authClient = createAuthClient({
-  plugins: [emailOTPClient()],
+  plugins: [emailOTPClient(), inferAdditionalFields<typeof auth>()],
 })

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,13 +23,14 @@ Item 1──* CheckoutLog
 
 ### Location
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| name | String | e.g., "The Warren Center - Central" |
-| address | String? | Optional full address |
-| createdAt | DateTime | Auto-set |
-| updatedAt | DateTime | Auto-updated |
+| Field     | Type          | Notes                                      |
+| --------- | ------------- | ------------------------------------------ |
+| id        | String (UUID) | Primary key                                |
+| name      | String        | e.g., "The Warren Center - Central"        |
+| address   | String?       | Optional full address                      |
+| status    | String        | `active` or `inactive` (default: `active`) |
+| createdAt | DateTime      | Auto-set                                   |
+| updatedAt | DateTime      | Auto-updated                               |
 
 ### User (extends Better Auth)
 
@@ -37,53 +38,54 @@ Better Auth provides: `id`, `email`, `emailVerified`, `image`, `createdAt`, `upd
 
 Additional fields:
 
-| Field | Type | Notes |
-|---|---|---|
-| legalFirstName | String | Required |
-| legalLastName | String | Required |
-| preferredFirstName | String? | Optional, displayed when present |
-| preferredLastName | String? | Optional, displayed when present |
-| role | String | `admin`, `supervisor`, or `employee` |
-| status | String | `active`, `on_leave`, or `inactive` |
+| Field              | Type    | Notes                                |
+| ------------------ | ------- | ------------------------------------ |
+| legalFirstName     | String  | Required                             |
+| legalLastName      | String  | Required                             |
+| preferredFirstName | String? | Optional, displayed when present     |
+| preferredLastName  | String? | Optional, displayed when present     |
+| role               | String  | `admin`, `supervisor`, or `employee` |
+| status             | String  | `active`, `on_leave`, or `inactive`  |
 
 The existing `name` field from Better Auth can be computed as the display name (preferred name if set, otherwise legal name).
 
 **Display name logic:**
+
 - First name: `preferredFirstName ?? legalFirstName`
 - Last name: `preferredLastName ?? legalLastName`
 
 ### Item
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| name | String | Human-readable item name |
-| description | String? | Optional details |
-| condition | String | `good`, `fair`, `damaged`, or `retired` |
-| status | String | `available` or `checked_out` |
-| homeLocationId | String (FK) | Location where item was originally assigned |
-| currentLocationId | String (FK) | Location where item currently resides (updates on check-in) |
-| qrCodeUrl | String | Stored path/data for the generated QR code |
-| createdAt | DateTime | Auto-set |
-| updatedAt | DateTime | Auto-updated |
+| Field             | Type          | Notes                                                       |
+| ----------------- | ------------- | ----------------------------------------------------------- |
+| id                | String (UUID) | Primary key                                                 |
+| name              | String        | Human-readable item name                                    |
+| description       | String?       | Optional details                                            |
+| condition         | String        | `good`, `fair`, `damaged`, or `retired`                     |
+| status            | String        | `available` or `checked_out`                                |
+| homeLocationId    | String (FK)   | Location where item was originally assigned                 |
+| currentLocationId | String (FK)   | Location where item currently resides (updates on check-in) |
+| qrCodeUrl         | String        | Stored path/data for the generated QR code                  |
+| createdAt         | DateTime      | Auto-set                                                    |
+| updatedAt         | DateTime      | Auto-updated                                                |
 
 ### CheckoutLog
 
 The audit trail. Each checkout creates a row. Check-in completes that row.
 
-| Field | Type | Notes |
-|---|---|---|
-| id | String (UUID) | Primary key |
-| itemId | String (FK) | The item being checked in/out |
-| userId | String (FK) | The person who has/had the item |
-| checkedOutBy | String (FK → User) | Admin/supervisor who performed checkout |
-| checkedOutFromLocationId | String (FK → Location) | Where the item was when checked out |
-| checkedOutAt | DateTime | When checkout occurred |
-| checkedInBy | String? (FK → User) | Admin/supervisor who performed check-in (null until returned) |
-| checkedInAtLocationId | String? (FK → Location) | Where the item was returned (null until returned) |
-| checkedInAt | DateTime? | When check-in occurred (null until returned) |
-| conditionOnReturn | String? | `good`, `fair`, `damaged`, or `retired` (null until returned) |
-| createdAt | DateTime | Auto-set |
+| Field                    | Type                    | Notes                                                         |
+| ------------------------ | ----------------------- | ------------------------------------------------------------- |
+| id                       | String (UUID)           | Primary key                                                   |
+| itemId                   | String (FK)             | The item being checked in/out                                 |
+| userId                   | String (FK)             | The person who has/had the item                               |
+| checkedOutBy             | String (FK → User)      | Admin/supervisor who performed checkout                       |
+| checkedOutFromLocationId | String (FK → Location)  | Where the item was when checked out                           |
+| checkedOutAt             | DateTime                | When checkout occurred                                        |
+| checkedInBy              | String? (FK → User)     | Admin/supervisor who performed check-in (null until returned) |
+| checkedInAtLocationId    | String? (FK → Location) | Where the item was returned (null until returned)             |
+| checkedInAt              | DateTime?               | When check-in occurred (null until returned)                  |
+| conditionOnReturn        | String?                 | `good`, `fair`, `damaged`, or `retired` (null until returned) |
+| createdAt                | DateTime                | Auto-set                                                      |
 
 ### Session, Account, Verification
 
@@ -91,12 +93,13 @@ These are Better Auth's default models — unchanged from the existing schema. S
 
 ## Enums (stored as strings)
 
-| Enum | Values |
-|---|---|
-| Role | `admin`, `supervisor`, `employee` |
-| UserStatus | `active`, `on_leave`, `inactive` |
-| ItemCondition | `good`, `fair`, `damaged`, `retired` |
-| ItemStatus | `available`, `checked_out` |
+| Enum           | Values                               |
+| -------------- | ------------------------------------ |
+| Role           | `admin`, `supervisor`, `employee`    |
+| UserStatus     | `active`, `on_leave`, `inactive`     |
+| LocationStatus | `active`, `inactive`                 |
+| ItemCondition  | `good`, `fair`, `damaged`, `retired` |
+| ItemStatus     | `available`, `checked_out`           |
 
 All enum transitions are allowed (e.g., an item can go from `retired` back to `good`, a user can move between any status).
 

--- a/docs/features/locations.md
+++ b/docs/features/locations.md
@@ -9,27 +9,29 @@ Locations represent the physical TWC facilities where equipment is stored and us
 See [data-model.md](../data-model.md) for the full `Location` schema.
 
 Fields:
+
 - **name**: Display name (e.g., "The Warren Center - Central")
 - **address**: Optional full street address
+- **status**: `active` or `inactive` (default: `active`)
 
 ## Permissions
 
-| Action | Admin | Supervisor | Employee |
-|---|---|---|---|
-| View locations | Yes | Yes | Yes |
-| Create location | Yes | No | No |
-| Edit location | Yes | No | No |
-| Delete location | Yes | No | No |
+| Action          | Admin | Supervisor | Employee |
+| --------------- | ----- | ---------- | -------- |
+| View locations  | Yes   | Yes        | Yes      |
+| Create location | Yes   | No         | No       |
+| Edit location   | Yes   | No         | No       |
+| Delete location | Yes   | No         | No       |
 
 ## Seed Locations
 
 Three locations are seeded at setup:
 
-| Name | Address |
-|---|---|
-| The Warren Center - Central | 320 Custer Rd, Richardson, TX 75080 |
-| The Warren Center - East | 2625 Anita Dr, Garland, TX 75041 |
-| The Warren Center - West | 400 E Royal Ln Suite 112, Irving, TX 75039 |
+| Name                        | Address                                    |
+| --------------------------- | ------------------------------------------ |
+| The Warren Center - Central | 320 Custer Rd, Richardson, TX 75080        |
+| The Warren Center - East    | 2625 Anita Dr, Garland, TX 75041           |
+| The Warren Center - West    | 400 E Royal Ln Suite 112, Irving, TX 75039 |
 
 ## Admin CRUD
 
@@ -46,6 +48,7 @@ Three locations are seeded at setup:
 **Route**: `/locations/[id]`
 
 Displays:
+
 - Location name and address
 - Count of items with this as home location
 - Count of items currently at this location
@@ -55,21 +58,27 @@ Displays:
 ### Create / Edit Form
 
 Fields:
+
 - **Name** (required)
 - **Address** (optional)
 
-### Delete
+### Deactivate (Soft Delete)
 
-Deleting a location requires handling items that reference it:
-- If any items have this as their `homeLocationId` or `currentLocationId`, deletion should be blocked with a message indicating the items must be reassigned first.
-- Alternatively, implement a soft-delete or require the admin to reassign items before deletion.
+Locations are never hard-deleted. Instead, admins set a location's status to `inactive`:
+
+- Inactive locations are hidden from normal lists and dropdowns (non-admin users cannot see them)
+- Admins can view inactive locations via a toggle on the location list page
+- Deactivation is blocked if any items have the location as their `currentLocationId` — items must be reassigned first
+- Items with an inactive location as `homeLocationId` are allowed (historical reference)
+- Admins can reactivate a location by setting its status back to `active`
+
+This mirrors the user model's `active`/`inactive` status pattern.
 
 ## API Routes
 
-| Method | Route | Description | Role |
-|---|---|---|---|
-| GET | `/api/locations` | List all locations | All |
-| GET | `/api/locations/[id]` | Get location detail with item counts | All |
-| POST | `/api/locations` | Create location | Admin |
-| PUT | `/api/locations/[id]` | Update location | Admin |
-| DELETE | `/api/locations/[id]` | Delete location (blocked if items exist) | Admin |
+| Method | Route                 | Description                                       | Role  |
+| ------ | --------------------- | ------------------------------------------------- | ----- |
+| GET    | `/api/locations`      | List all locations                                | All   |
+| GET    | `/api/locations/[id]` | Get location detail with item counts              | All   |
+| POST   | `/api/locations`      | Create location                                   | Admin |
+| PUT    | `/api/locations/[id]` | Update location (including deactivate/reactivate) | Admin |

--- a/prisma/migrations/20260425050534_add_location_status/migration.sql
+++ b/prisma/migrations/20260425050534_add_location_status/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_location" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "address" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_location" ("address", "createdAt", "id", "name", "updatedAt") SELECT "address", "createdAt", "id", "name", "updatedAt" FROM "location";
+DROP TABLE "location";
+ALTER TABLE "new_location" RENAME TO "location";
+CREATE UNIQUE INDEX "location_name_key" ON "location"("name");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,7 @@ model Location {
   id        String   @id @default(uuid())
   name      String
   address   String?
+  status    String   @default("active")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/server/api/locations/[id].get.ts
+++ b/server/api/locations/[id].get.ts
@@ -1,0 +1,47 @@
+export default defineEventHandler(async (event) => {
+  const session = event.context.session
+  const id = getRouterParam(event, 'id')
+
+  const location = await prisma.location.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      address: true,
+      status: true,
+      _count: {
+        select: {
+          homeItems: true,
+          currentItems: true,
+        },
+      },
+      currentItems: {
+        select: {
+          id: true,
+          name: true,
+          condition: true,
+          status: true,
+        },
+      },
+    },
+  })
+
+  if (!location) {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  // Non-admins cannot view inactive locations
+  if (location.status === 'inactive' && session.user.role !== 'admin') {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  return {
+    id: location.id,
+    name: location.name,
+    address: location.address,
+    status: location.status,
+    homeItemCount: location._count.homeItems,
+    currentItemCount: location._count.currentItems,
+    currentItems: location.currentItems,
+  }
+})

--- a/server/api/locations/[id].put.ts
+++ b/server/api/locations/[id].put.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+const updateLocationSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200).optional(),
+  address: z.string().max(500).nullable().optional(),
+  status: z.enum(['active', 'inactive']).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  requireRole(event, 'admin')
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const parsed = updateLocationSchema.safeParse(body)
+
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation failed',
+      data: parsed.error.flatten().fieldErrors,
+    })
+  }
+
+  const existing = await prisma.location.findUnique({ where: { id } })
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Location not found' })
+  }
+
+  // Block deactivation if items are currently at this location
+  if (parsed.data.status === 'inactive' && existing.status === 'active') {
+    const itemCount = await prisma.item.count({
+      where: { currentLocationId: id },
+    })
+    if (itemCount > 0) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: `Cannot deactivate: ${itemCount} item${itemCount === 1 ? ' is' : 's are'} currently at this location. Reassign them first.`,
+      })
+    }
+  }
+
+  const updated = await prisma.location.update({
+    where: { id },
+    data: parsed.data,
+  })
+
+  return updated
+})

--- a/server/api/locations/index.get.ts
+++ b/server/api/locations/index.get.ts
@@ -1,0 +1,39 @@
+export default defineEventHandler(async (event) => {
+  const session = event.context.session
+  const query = getQuery(event)
+
+  // Non-admins always see active only
+  let statusFilter: string | undefined = 'active'
+  if (session.user.role === 'admin') {
+    const requested = query.status as string | undefined
+    if (requested === 'inactive') statusFilter = 'inactive'
+    else if (requested === 'all') statusFilter = undefined
+    // default: 'active'
+  }
+
+  const locations = await prisma.location.findMany({
+    where: statusFilter ? { status: statusFilter } : undefined,
+    select: {
+      id: true,
+      name: true,
+      address: true,
+      status: true,
+      _count: {
+        select: {
+          homeItems: true,
+          currentItems: true,
+        },
+      },
+    },
+    orderBy: { name: 'asc' },
+  })
+
+  return locations.map((loc) => ({
+    id: loc.id,
+    name: loc.name,
+    address: loc.address,
+    status: loc.status,
+    homeItemCount: loc._count.homeItems,
+    currentItemCount: loc._count.currentItems,
+  }))
+})

--- a/server/api/locations/index.post.ts
+++ b/server/api/locations/index.post.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+const createLocationSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  address: z.string().max(500).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  requireRole(event, 'admin')
+
+  const body = await readBody(event)
+  const parsed = createLocationSchema.safeParse(body)
+
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation failed',
+      data: parsed.error.flatten().fieldErrors,
+    })
+  }
+
+  const location = await prisma.location.create({
+    data: {
+      name: parsed.data.name,
+      address: parsed.data.address ?? null,
+    },
+  })
+
+  setResponseStatus(event, 201)
+  return location
+})

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,12 +1,4 @@
-export default defineEventHandler(async (event) => {
-  const session = await auth.api.getSession({
-    headers: event.headers,
-  })
-
-  if (!session) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
-
+export default defineEventHandler(async () => {
   const users = await prisma.user.findMany({
     select: {
       id: true,

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,17 @@
+export default defineEventHandler(async (event) => {
+  const path = getRequestURL(event).pathname
+
+  // Skip auth routes — Better Auth handles these
+  if (path.startsWith('/api/auth/')) return
+
+  // Only protect /api/* routes
+  if (!path.startsWith('/api/')) return
+
+  const session = await auth.api.getSession({ headers: event.headers })
+
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  event.context.session = session
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -26,6 +26,36 @@ export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: 'sqlite',
   }),
+  user: {
+    additionalFields: {
+      role: {
+        type: 'string',
+        required: false,
+        defaultValue: 'employee',
+      },
+      status: {
+        type: 'string',
+        required: false,
+        defaultValue: 'active',
+      },
+      legalFirstName: {
+        type: 'string',
+        required: false,
+      },
+      legalLastName: {
+        type: 'string',
+        required: false,
+      },
+      preferredFirstName: {
+        type: 'string',
+        required: false,
+      },
+      preferredLastName: {
+        type: 'string',
+        required: false,
+      },
+    },
+  },
   plugins: [
     emailOTP({
       async sendVerificationOTP({ email, otp, type: _type }) {

--- a/server/utils/require-role.test.ts
+++ b/server/utils/require-role.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { requireRole } from './require-role'
+import type { H3Event } from 'h3'
+
+function mockEvent(role?: string): H3Event {
+  return {
+    context: {
+      session: role ? { user: { role } } : null,
+    },
+  } as unknown as H3Event
+}
+
+describe('requireRole', () => {
+  it('allows access when user has the required role', () => {
+    expect(() => requireRole(mockEvent('admin'), 'admin')).not.toThrow()
+  })
+
+  it('allows access when user has one of multiple allowed roles', () => {
+    expect(() => requireRole(mockEvent('supervisor'), 'admin', 'supervisor')).not.toThrow()
+  })
+
+  it('throws 403 when user role does not match', () => {
+    expect(() => requireRole(mockEvent('employee'), 'admin')).toThrow()
+  })
+
+  it('throws 403 when session is missing', () => {
+    const event = { context: {} } as unknown as H3Event
+    expect(() => requireRole(event, 'admin')).toThrow()
+  })
+})

--- a/server/utils/require-role.ts
+++ b/server/utils/require-role.ts
@@ -1,0 +1,10 @@
+import type { H3Event } from 'h3'
+
+type Role = 'admin' | 'supervisor' | 'employee'
+
+export function requireRole(event: H3Event, ...roles: Role[]) {
+  const session = event.context.session
+  if (!session || !roles.includes(session.user.role as Role)) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+}


### PR DESCRIPTION
## Summary
- Add location CRUD API routes with role-based access and soft-delete (deactivate/reactivate) instead of hard delete
- Add server auth middleware (`server/middleware/auth.ts`) and `requireRole` utility for all future API routes
- Add location list page with active/inactive toggle for admins, and location detail page with item counts
- Register custom user fields (`role`, `status`, names) in Better Auth config so session types include them

## Changes

### Schema
- Add `status` field to `Location` model (default: `active`)

### Backend
- `server/middleware/auth.ts` — attaches session to `event.context` for all `/api/*` routes
- `server/utils/require-role.ts` — one-liner role enforcement for route handlers
- `server/api/locations/index.get.ts` — list locations (admins can filter by status)
- `server/api/locations/index.post.ts` — create location (admin only, Zod validation)
- `server/api/locations/[id].get.ts` — detail with item counts (non-admins get 404 for inactive)
- `server/api/locations/[id].put.ts` — update including deactivate/reactivate (blocks deactivation if items present)
- `server/utils/auth.ts` — added `user.additionalFields` for type-safe session access

### Frontend
- `app/pages/locations/index.vue` — location list with create/edit modal, active/inactive toggle, deactivate/reactivate
- `app/pages/locations/[id].vue` — detail page with edit modal, admin actions
- `app/utils/auth-client.ts` — uses `inferAdditionalFields` for typed session

### Tests
- `server/utils/require-role.test.ts` — unit tests for role enforcement

## Test plan
- [x] `GET /api/locations` returns active locations by default
- [x] `GET /api/locations?status=inactive` returns inactive locations (admin only)
- [x] `GET /api/locations/[id]` returns detail with item counts
- [x] `POST /api/locations` creates location (admin only, validates input)
- [x] `PUT /api/locations/[id]` updates location (admin only)
- [x] PUT deactivation blocked when items are at the location (409)
- [x] PUT reactivation works
- [x] Non-admin requests to mutating endpoints return 403
- [x] `/locations` page renders with active/inactive toggle for admin
- [x] Admin can create, edit, deactivate, reactivate locations
- [x] Non-admin sees read-only active locations
- [x] Lint passes
- [x] Type check passes
- [x] Unit tests pass

## Docs updated
- `docs/features/locations.md` — soft delete behavior, updated API routes table
- `docs/data-model.md` — Location status field, LocationStatus enum
- `CLAUDE.md` — new pages, middleware, API routes, schema models

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)