### PR TITLE
Add check-out flow: API route and admin/supervisor UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail), `/profile` (self-service profile)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out modal), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail), `/profile` (self-service profile)
 
 ### Backend (`server/`)
 
@@ -33,7 +33,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
 - **Display name utility**: `server/utils/display-name.ts` — computes display name from preferred/legal name fields
-- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD)
+- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow)
 - **No hard deletes**: All entities use soft delete — locations set `status: 'inactive'`, users set `status: 'inactive'`, items set `condition: 'retired'`. This preserves checkout history.
 
 ### Database (`prisma/`)

--- a/app/pages/items/[id].vue
+++ b/app/pages/items/[id].vue
@@ -49,6 +49,12 @@
   // Fetch locations for edit form
   const { data: locations } = await useFetch('/api/locations')
 
+  // Fetch users for checkout modal (admin/supervisor only)
+  const { data: users } = await useFetch('/api/users', {
+    immediate: isAdminOrSupervisor.value,
+    watch: false,
+  })
+
   // Edit modal
   const isEditOpen = ref(false)
   const isSubmitting = ref(false)
@@ -99,6 +105,51 @@
       toast.add({ title: 'Error', description: message, color: 'error' })
     } finally {
       isSubmitting.value = false
+    }
+  }
+
+  // Checkout modal
+  const isCheckoutOpen = ref(false)
+  const isCheckingOut = ref(false)
+  const selectedUserId = ref('')
+
+  const userOptions = computed(() =>
+    (users.value ?? []).map((u: { id: string; displayName: string; email: string }) => ({
+      label: `${u.displayName} (${u.email})`,
+      value: u.id,
+    }))
+  )
+
+  const selectedUser = computed(() =>
+    (users.value ?? []).find((u: { id: string; status: string }) => u.id === selectedUserId.value)
+  )
+
+  function openCheckout() {
+    selectedUserId.value = ''
+    isCheckoutOpen.value = true
+  }
+
+  async function handleCheckout() {
+    isCheckingOut.value = true
+    try {
+      const result = await $fetch<{ warning?: string }>(`/api/items/${id}/checkout`, {
+        method: 'POST',
+        body: { userId: selectedUserId.value },
+      })
+      toast.add({ title: 'Item checked out', color: 'success' })
+      if (result.warning) {
+        toast.add({ title: 'Warning', description: result.warning, color: 'warning' })
+      }
+      isCheckoutOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : 'Something went wrong'
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    } finally {
+      isCheckingOut.value = false
     }
   }
 
@@ -237,8 +288,7 @@
                   icon="i-heroicons-arrow-right-circle-20-solid"
                   label="Check Out"
                   size="sm"
-                  disabled
-                  title="Coming soon"
+                  @click="openCheckout"
                 />
                 <UButton
                   v-else-if="item.status === 'checked_out'"
@@ -381,6 +431,58 @@
         </div>
       </UCard>
     </template>
+
+    <!-- Checkout Modal -->
+    <UModal v-model:open="isCheckoutOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Check Out Item</h3>
+
+          <div class="mb-4 space-y-2">
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Item</p>
+              <p class="text-gray-900 dark:text-white">{{ item?.name }}</p>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">From Location</p>
+              <p class="text-gray-900 dark:text-white">{{ item?.currentLocation.name }}</p>
+            </div>
+          </div>
+
+          <UFormField label="Check out to" name="userId" required class="mb-4">
+            <USelect
+              v-model="selectedUserId"
+              :items="userOptions"
+              placeholder="Select a user..."
+              class="w-full"
+            />
+          </UFormField>
+
+          <UAlert
+            v-if="selectedUser?.status === 'on_leave'"
+            class="mb-4"
+            icon="i-heroicons-exclamation-triangle-20-solid"
+            color="warning"
+            variant="subtle"
+            title="This user is currently on leave"
+          />
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isCheckoutOpen = false">
+              Cancel
+            </UButton>
+            <UButton
+              color="primary"
+              :loading="isCheckingOut"
+              :disabled="!selectedUserId"
+              @click="handleCheckout"
+            >
+              Check Out
+            </UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
 
     <!-- Edit Modal -->
     <UModal v-model:open="isEditOpen">

--- a/app/pages/items/[id].vue
+++ b/app/pages/items/[id].vue
@@ -111,7 +111,7 @@
   // Checkout modal
   const isCheckoutOpen = ref(false)
   const isCheckingOut = ref(false)
-  const selectedUserId = ref('')
+  const selectedUserOption = ref<{ label: string; value: string } | undefined>()
 
   const userOptions = computed(() =>
     (users.value ?? []).map((u: { id: string; displayName: string; email: string }) => ({
@@ -121,20 +121,23 @@
   )
 
   const selectedUser = computed(() =>
-    (users.value ?? []).find((u: { id: string; status: string }) => u.id === selectedUserId.value)
+    (users.value ?? []).find(
+      (u: { id: string; status: string }) => u.id === selectedUserOption.value?.value
+    )
   )
 
   function openCheckout() {
-    selectedUserId.value = ''
+    selectedUserOption.value = undefined
     isCheckoutOpen.value = true
   }
 
   async function handleCheckout() {
+    if (!selectedUserOption.value) return
     isCheckingOut.value = true
     try {
       const result = await $fetch<{ warning?: string }>(`/api/items/${id}/checkout`, {
         method: 'POST',
-        body: { userId: selectedUserId.value },
+        body: { userId: selectedUserOption.value.value },
       })
       toast.add({ title: 'Item checked out', color: 'success' })
       if (result.warning) {
@@ -450,9 +453,10 @@
           </div>
 
           <UFormField label="Check out to" name="userId" required class="mb-4">
-            <USelect
-              v-model="selectedUserId"
+            <USelectMenu
+              v-model="selectedUserOption"
               :items="userOptions"
+              :search-input="{ placeholder: 'Search by name or email...' }"
               placeholder="Select a user..."
               class="w-full"
             />
@@ -474,7 +478,7 @@
             <UButton
               color="primary"
               :loading="isCheckingOut"
-              :disabled="!selectedUserId"
+              :disabled="!selectedUserOption"
               @click="handleCheckout"
             >
               Check Out

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -16,6 +16,18 @@
     emailVerified: boolean
     createdAt: string
     updatedAt: string
+    checkoutHistory: {
+      id: string
+      item: { id: string; name: string }
+      checkedOutBy: { id: string; name: string }
+      checkedOutFromLocation: { id: string; name: string }
+      checkedOutAt: string
+      checkedInBy: { id: string; name: string } | null
+      checkedInAtLocation: { id: string; name: string } | null
+      checkedInAt: string | null
+      conditionOnReturn: string | null
+      isOpen: boolean
+    }[]
   }
 
   const route = useRoute()
@@ -95,6 +107,16 @@
     if (status === 'active') return 'success' as const
     if (status === 'on_leave') return 'warning' as const
     return 'neutral' as const
+  }
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
   }
 
   function getImageLink() {
@@ -202,7 +224,7 @@
         </div>
       </UCard>
 
-      <!-- Checkout History Placeholder -->
+      <!-- Checkout History -->
       <UCard class="mt-6">
         <template #header>
           <div class="flex items-center gap-2">
@@ -213,8 +235,46 @@
             <h2 class="text-base font-semibold text-gray-900 dark:text-white">Checkout History</h2>
           </div>
         </template>
-        <div class="py-6 text-center text-gray-500">
-          Checkout history will appear here once the check-in/check-out system is implemented.
+        <div v-if="!user.checkoutHistory.length" class="py-6 text-center text-gray-500">
+          No checkout history yet.
+        </div>
+        <div v-else class="space-y-3">
+          <div
+            v-for="log in user.checkoutHistory"
+            :key="log.id"
+            class="rounded-lg border p-3"
+            :class="
+              log.isOpen
+                ? 'border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-950'
+                : 'border-gray-200 dark:border-gray-700'
+            "
+          >
+            <div class="flex items-center justify-between">
+              <div class="text-sm">
+                <NuxtLink
+                  :to="`/items/${log.item.id}`"
+                  class="text-primary-500 font-medium hover:underline"
+                >
+                  {{ log.item.name }}
+                </NuxtLink>
+                <span class="text-gray-500 dark:text-gray-400">
+                  &mdash; checked out by {{ log.checkedOutBy.name }} from
+                  {{ log.checkedOutFromLocation.name }}
+                </span>
+              </div>
+              <UBadge v-if="log.isOpen" color="warning" variant="subtle" size="sm"> open </UBadge>
+            </div>
+            <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Out: {{ formatDate(log.checkedOutAt) }}
+              <template v-if="log.checkedInAt">
+                &bull; In: {{ formatDate(log.checkedInAt) }} at
+                {{ log.checkedInAtLocation?.name }} by {{ log.checkedInBy?.name }}
+                <template v-if="log.conditionOnReturn">
+                  &bull; Condition: {{ log.conditionOnReturn }}
+                </template>
+              </template>
+            </div>
+          </div>
         </div>
       </UCard>
     </template>

--- a/server/api/items/[id]/checkout.post.ts
+++ b/server/api/items/[id]/checkout.post.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+
+const checkoutSchema = z.object({
+  userId: z.string().uuid('Invalid user ID'),
+})
+
+export default defineEventHandler(async (event) => {
+  requireRole(event, 'admin', 'supervisor')
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const parsed = checkoutSchema.safeParse(body)
+
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation failed',
+      data: parsed.error.flatten().fieldErrors,
+    })
+  }
+
+  // Validate item exists and is available
+  const item = await prisma.item.findUnique({
+    where: { id },
+    select: { id: true, name: true, status: true, currentLocationId: true },
+  })
+
+  if (!item) {
+    throw createError({ statusCode: 404, statusMessage: 'Item not found' })
+  }
+
+  if (item.status !== 'available') {
+    throw createError({ statusCode: 409, statusMessage: 'Item is not available for checkout' })
+  }
+
+  // Validate user exists and is not inactive
+  const targetUser = await prisma.user.findUnique({
+    where: { id: parsed.data.userId },
+    select: { id: true, name: true, status: true },
+  })
+
+  if (!targetUser) {
+    throw createError({ statusCode: 400, statusMessage: 'User not found' })
+  }
+
+  if (targetUser.status === 'inactive') {
+    throw createError({ statusCode: 400, statusMessage: 'Cannot check out to an inactive user' })
+  }
+
+  // Atomically create checkout log and update item status
+  const session = event.context.session
+  const warning = targetUser.status === 'on_leave' ? 'User is currently on leave' : undefined
+
+  const checkoutLog = await prisma.$transaction(async (tx) => {
+    const log = await tx.checkoutLog.create({
+      data: {
+        itemId: item.id,
+        userId: parsed.data.userId,
+        checkedOutBy: session.user.id,
+        checkedOutFromLocationId: item.currentLocationId,
+      },
+      select: {
+        id: true,
+        checkedOutAt: true,
+        user: { select: { id: true, name: true } },
+        checkedOutByUser: { select: { id: true, name: true } },
+        checkedOutFromLocation: { select: { id: true, name: true } },
+      },
+    })
+
+    await tx.item.update({
+      where: { id: item.id },
+      data: { status: 'checked_out' },
+    })
+
+    return log
+  })
+
+  setResponseStatus(event, 201)
+  return {
+    id: checkoutLog.id,
+    checkedOutAt: checkoutLog.checkedOutAt,
+    item: { id: item.id, name: item.name },
+    user: checkoutLog.user,
+    checkedOutBy: checkoutLog.checkedOutByUser,
+    checkedOutFromLocation: checkoutLog.checkedOutFromLocation,
+    warning,
+  }
+})

--- a/server/api/users/[id]/index.get.ts
+++ b/server/api/users/[id]/index.get.ts
@@ -23,6 +23,31 @@ export default defineEventHandler(async (event) => {
       preferredLastName: true,
       createdAt: true,
       updatedAt: true,
+      itemsHeld: {
+        orderBy: { checkedOutAt: 'desc' },
+        take: 10,
+        select: {
+          id: true,
+          checkedOutAt: true,
+          checkedInAt: true,
+          conditionOnReturn: true,
+          item: {
+            select: { id: true, name: true },
+          },
+          checkedOutByUser: {
+            select: { id: true, name: true },
+          },
+          checkedOutFromLocation: {
+            select: { id: true, name: true },
+          },
+          checkedInByUser: {
+            select: { id: true, name: true },
+          },
+          checkedInAtLocation: {
+            select: { id: true, name: true },
+          },
+        },
+      },
     },
   })
 
@@ -34,5 +59,17 @@ export default defineEventHandler(async (event) => {
     ...user,
     displayName: getDisplayName(user),
     image: user.image != null,
+    checkoutHistory: user.itemsHeld.map((log) => ({
+      id: log.id,
+      item: log.item,
+      checkedOutBy: log.checkedOutByUser,
+      checkedOutFromLocation: log.checkedOutFromLocation,
+      checkedOutAt: log.checkedOutAt,
+      checkedInBy: log.checkedInByUser,
+      checkedInAtLocation: log.checkedInAtLocation,
+      checkedInAt: log.checkedInAt,
+      conditionOnReturn: log.conditionOnReturn,
+      isOpen: log.checkedInAt === null,
+    })),
   }
 })

--- a/tests/api/checkout.test.ts
+++ b/tests/api/checkout.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Test the validation schema used by the checkout API route.
+// Mirrors the schema in server/api/items/[id]/checkout.post.ts.
+
+const checkoutSchema = z.object({
+  userId: z.string().uuid('Invalid user ID'),
+})
+
+describe('checkout API validation', () => {
+  describe('checkout schema', () => {
+    it('accepts valid userId', () => {
+      const result = checkoutSchema.safeParse({
+        userId: '550e8400-e29b-41d4-a716-446655440000',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects missing userId', () => {
+      const result = checkoutSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-UUID userId', () => {
+      const result = checkoutSchema.safeParse({ userId: 'not-a-uuid' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty userId', () => {
+      const result = checkoutSchema.safeParse({ userId: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-string userId', () => {
+      const result = checkoutSchema.safeParse({ userId: 123 })
+      expect(result.success).toBe(false)
+    })
+
+    it('ignores extra fields', () => {
+      const result = checkoutSchema.safeParse({
+        userId: '550e8400-e29b-41d4-a716-446655440000',
+        extra: 'field',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `POST /api/items/:id/checkout` endpoint — validates item is available, user is not inactive, atomically creates CheckoutLog and updates item status in a transaction
- Add check-out modal to item detail page — user selection dropdown, on_leave warning, success/error toasts
- Add checkout API validation tests (Zod schema)

Closes #7

## Test plan

- [x] All 67 tests pass (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (pre-commit hooks)
- [ ] Manual: navigate to item detail as admin/supervisor → click Check Out → select user → submit → verify item shows as checked out with history entry
- [ ] Manual: verify 409 when trying to check out an already checked-out item
- [ ] Manual: verify on_leave warning appears when selecting an on-leave user

🤖 Generated with [Claude Code](https://claude.com/claude-code)