### PR TITLE
Check-in flow: API route and admin/supervisor UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out modal), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail), `/profile` (self-service profile)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out and check-in modals), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail), `/profile` (self-service profile)
 
 ### Backend (`server/`)
 
@@ -33,7 +33,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
 - **Display name utility**: `server/utils/display-name.ts` — computes display name from preferred/legal name fields
-- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow)
+- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow)
 - **No hard deletes**: All entities use soft delete — locations set `status: 'inactive'`, users set `status: 'inactive'`, items set `condition: 'retired'`. This preserves checkout history.
 
 ### Database (`prisma/`)

--- a/app/pages/items/[id].vue
+++ b/app/pages/items/[id].vue
@@ -156,6 +156,52 @@
     }
   }
 
+  // Check-in modal
+  const isCheckinOpen = ref(false)
+  const isCheckingIn = ref(false)
+  const checkinLocationId = ref('')
+  const checkinCondition = ref<'good' | 'fair' | 'damaged' | 'retired'>('good')
+
+  const locationOptions = computed(() =>
+    (locations.value ?? []).map((loc: { id: string; name: string }) => ({
+      label: loc.name,
+      value: loc.id,
+    }))
+  )
+
+  function openCheckin() {
+    if (!item.value) return
+    checkinLocationId.value = item.value.homeLocation.id
+    checkinCondition.value =
+      (item.value.condition as 'good' | 'fair' | 'damaged' | 'retired') || 'good'
+    isCheckinOpen.value = true
+  }
+
+  async function handleCheckin() {
+    if (!checkinLocationId.value || !checkinCondition.value) return
+    isCheckingIn.value = true
+    try {
+      await $fetch(`/api/items/${id}/checkin`, {
+        method: 'POST',
+        body: {
+          locationId: checkinLocationId.value,
+          condition: checkinCondition.value,
+        },
+      })
+      toast.add({ title: 'Item checked in', color: 'success' })
+      isCheckinOpen.value = false
+      await refresh()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'statusMessage' in err
+          ? (err as { statusMessage: string }).statusMessage
+          : 'Something went wrong'
+      toast.add({ title: 'Error', description: message, color: 'error' })
+    } finally {
+      isCheckingIn.value = false
+    }
+  }
+
   // Retire / Reactivate
   const isRetiring = ref(false)
 
@@ -300,8 +346,7 @@
                   icon="i-heroicons-arrow-left-circle-20-solid"
                   label="Check In"
                   size="sm"
-                  disabled
-                  title="Coming soon"
+                  @click="openCheckin"
                 />
               </template>
               <template v-if="isAdmin">
@@ -482,6 +527,67 @@
               @click="handleCheckout"
             >
               Check Out
+            </UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Check-in Modal -->
+    <UModal v-model:open="isCheckinOpen">
+      <template #content>
+        <div class="p-6">
+          <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Check In Item</h3>
+
+          <div class="mb-4 space-y-2">
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Item</p>
+              <p class="text-gray-900 dark:text-white">{{ item?.name }}</p>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Returning for</p>
+              <p class="text-gray-900 dark:text-white">
+                {{ item?.currentCheckout?.user.name }}
+              </p>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Checked out from</p>
+              <p class="text-gray-900 dark:text-white">
+                {{ item?.currentCheckout?.checkedOutFromLocation.name }}
+              </p>
+            </div>
+          </div>
+
+          <div class="mb-4 space-y-4">
+            <UFormField label="Check-in location" name="locationId" required>
+              <USelect v-model="checkinLocationId" :items="locationOptions" class="w-full" />
+            </UFormField>
+
+            <UFormField label="Condition on return" name="condition" required>
+              <USelect
+                v-model="checkinCondition"
+                :items="[
+                  { label: 'Good', value: 'good' },
+                  { label: 'Fair', value: 'fair' },
+                  { label: 'Damaged', value: 'damaged' },
+                  { label: 'Retired', value: 'retired' },
+                ]"
+                class="w-full"
+              />
+            </UFormField>
+          </div>
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="soft" color="neutral" @click="isCheckinOpen = false">
+              Cancel
+            </UButton>
+            <UButton
+              color="primary"
+              :loading="isCheckingIn"
+              :disabled="!checkinLocationId || !checkinCondition"
+              @click="handleCheckin"
+            >
+              Check In
             </UButton>
           </div>
         </div>

--- a/server/api/items/[id]/checkin.post.ts
+++ b/server/api/items/[id]/checkin.post.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+const checkinSchema = z.object({
+  locationId: z.string().uuid('Invalid location ID'),
+  condition: z.enum(['good', 'fair', 'damaged', 'retired'], {
+    error: 'Condition must be good, fair, damaged, or retired',
+  }),
+})
+
+export default defineEventHandler(async (event) => {
+  requireRole(event, 'admin', 'supervisor')
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const parsed = checkinSchema.safeParse(body)
+
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation failed',
+      data: parsed.error.flatten().fieldErrors,
+    })
+  }
+
+  // Validate item exists and is checked out
+  const item = await prisma.item.findUnique({
+    where: { id },
+    select: { id: true, name: true, status: true },
+  })
+
+  if (!item) {
+    throw createError({ statusCode: 404, statusMessage: 'Item not found' })
+  }
+
+  if (item.status !== 'checked_out') {
+    throw createError({ statusCode: 409, statusMessage: 'Item is not currently checked out' })
+  }
+
+  // Validate location exists
+  const location = await prisma.location.findUnique({
+    where: { id: parsed.data.locationId },
+    select: { id: true, name: true },
+  })
+
+  if (!location) {
+    throw createError({ statusCode: 400, statusMessage: 'Location not found' })
+  }
+
+  // Find open checkout log and complete it atomically
+  const session = event.context.session
+
+  const checkoutLog = await prisma.$transaction(async (tx) => {
+    const openLog = await tx.checkoutLog.findFirst({
+      where: { itemId: item.id, checkedInAt: null },
+    })
+
+    if (!openLog) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'No open checkout log found for this item',
+      })
+    }
+
+    const log = await tx.checkoutLog.update({
+      where: { id: openLog.id },
+      data: {
+        checkedInBy: session.user.id,
+        checkedInAtLocationId: parsed.data.locationId,
+        checkedInAt: new Date(),
+        conditionOnReturn: parsed.data.condition,
+      },
+      select: {
+        id: true,
+        checkedOutAt: true,
+        checkedInAt: true,
+        conditionOnReturn: true,
+        user: { select: { id: true, name: true } },
+        checkedOutByUser: { select: { id: true, name: true } },
+        checkedOutFromLocation: { select: { id: true, name: true } },
+        checkedInByUser: { select: { id: true, name: true } },
+        checkedInAtLocation: { select: { id: true, name: true } },
+      },
+    })
+
+    await tx.item.update({
+      where: { id: item.id },
+      data: {
+        status: 'available',
+        condition: parsed.data.condition,
+        currentLocationId: parsed.data.locationId,
+      },
+    })
+
+    return log
+  })
+
+  return {
+    id: checkoutLog.id,
+    item: { id: item.id, name: item.name },
+    user: checkoutLog.user,
+    checkedOutBy: checkoutLog.checkedOutByUser,
+    checkedOutFromLocation: checkoutLog.checkedOutFromLocation,
+    checkedOutAt: checkoutLog.checkedOutAt,
+    checkedInBy: checkoutLog.checkedInByUser,
+    checkedInAtLocation: checkoutLog.checkedInAtLocation,
+    checkedInAt: checkoutLog.checkedInAt,
+    conditionOnReturn: checkoutLog.conditionOnReturn,
+  }
+})

--- a/tests/api/checkin.test.ts
+++ b/tests/api/checkin.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Test the validation schema used by the checkin API route.
+// Mirrors the schema in server/api/items/[id]/checkin.post.ts.
+
+const checkinSchema = z.object({
+  locationId: z.string().uuid('Invalid location ID'),
+  condition: z.enum(['good', 'fair', 'damaged', 'retired'], {
+    error: 'Condition must be good, fair, damaged, or retired',
+  }),
+})
+
+describe('checkin API validation', () => {
+  describe('checkin schema', () => {
+    it('accepts valid locationId and condition', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+        condition: 'good',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts all valid condition values', () => {
+      const conditions = ['good', 'fair', 'damaged', 'retired'] as const
+      for (const condition of conditions) {
+        const result = checkinSchema.safeParse({
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+          condition,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+
+    it('rejects missing locationId', () => {
+      const result = checkinSchema.safeParse({ condition: 'good' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-UUID locationId', () => {
+      const result = checkinSchema.safeParse({
+        locationId: 'not-a-uuid',
+        condition: 'good',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty locationId', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '',
+        condition: 'good',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects missing condition', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects invalid condition value', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+        condition: 'broken',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty condition', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+        condition: '',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-string condition', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+        condition: 123,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty body', () => {
+      const result = checkinSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+
+    it('ignores extra fields', () => {
+      const result = checkinSchema.safeParse({
+        locationId: '550e8400-e29b-41d4-a716-446655440000',
+        condition: 'fair',
+        extra: 'field',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Closes #8

## Summary

- **API route** `POST /api/items/[id]/checkin` — validates item is checked out, accepts `locationId` and `condition`, atomically completes the open CheckoutLog and updates item status/condition/location
- **Check-in modal** on item detail page — replaces the disabled "Coming soon" button with a working modal showing item info, returning user, location dropdown (pre-selects home location), and condition selector (pre-selects current condition)
- **Validation tests** for the checkin Zod schema covering all field combinations
- **CLAUDE.md** updated with the new route

## Test plan

- [ ] Check out an item, then check it in via the modal — verify item shows as available with updated condition and location
- [ ] Verify 409 when trying to check in an item that's already available
- [ ] Verify 403 when employee role tries the endpoint
- [ ] Verify modal pre-selects home location and current condition
- [ ] `pnpm test` passes (78 tests)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)