### PR TITLE
Audit trail and history views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out and check-in modals), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail), `/profile` (self-service profile)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
 
 ### Backend (`server/`)
 
@@ -33,7 +33,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
 - **Display name utility**: `server/utils/display-name.ts` — computes display name from preferred/legal name fields
-- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow)
+- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint, `GET /api/users/[id]/history` for checkout history), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow, `GET /api/items/[id]/history` for checkout history), `server/api/checkouts/` (`GET /api/checkouts/open` for open checkouts dashboard)
 - **No hard deletes**: All entities use soft delete — locations set `status: 'inactive'`, users set `status: 'inactive'`, items set `condition: 'retired'`. This preserves checkout history.
 
 ### Database (`prisma/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **UI**: Nuxt UI v3 components (`UButton`, `UCard`, `UModal`, etc.) with Tailwind CSS
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
+- **Header**: `UHeader` component with `UNavigationMenu` — responsive hamburger menu on mobile (<lg), horizontal nav on desktop
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard with live stats and recent activity), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
 
 ### Backend (`server/`)
 
@@ -33,7 +34,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
 - **Display name utility**: `server/utils/display-name.ts` — computes display name from preferred/legal name fields
-- **API routes**: `server/api/users/` (user CRUD, profile pictures, `/me` endpoint, `GET /api/users/[id]/history` for checkout history), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow, `GET /api/items/[id]/history` for checkout history), `server/api/checkouts/` (`GET /api/checkouts/open` for open checkouts dashboard)
+- **API routes**: `server/api/dashboard.get.ts` (aggregated stats and recent activity), `server/api/users/` (user CRUD, profile pictures, `/me` endpoint, `GET /api/users/[id]/history` for checkout history), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow, `GET /api/items/[id]/history` for checkout history), `server/api/checkouts/` (`GET /api/checkouts/open` for open checkouts dashboard)
 - **No hard deletes**: All entities use soft delete — locations set `status: 'inactive'`, users set `status: 'inactive'`, items set `condition: 'retired'`. This preserves checkout history.
 
 ### Database (`prisma/`)

--- a/app/app.vue
+++ b/app/app.vue
@@ -23,6 +23,11 @@
       { to: '/items', label: 'Items', icon: 'i-heroicons-cube-20-solid' },
     ]
     if (userRole.value === 'admin' || userRole.value === 'supervisor') {
+      links.push({
+        to: '/checkouts',
+        label: 'Checkouts',
+        icon: 'i-heroicons-clipboard-document-list-20-solid',
+      })
       links.push({ to: '/users', label: 'Users', icon: 'i-heroicons-users-20-solid' })
     }
     links.push({ to: '/profile', label: 'Profile', icon: 'i-heroicons-user-circle-20-solid' })

--- a/app/app.vue
+++ b/app/app.vue
@@ -18,7 +18,6 @@
   const navLinks = computed(() => {
     if (!isLoggedIn.value) return []
     const links = [
-      { to: '/', label: 'Dashboard', icon: 'i-heroicons-home-20-solid' },
       { to: '/locations', label: 'Locations', icon: 'i-heroicons-map-pin-20-solid' },
       { to: '/items', label: 'Items', icon: 'i-heroicons-cube-20-solid' },
     ]

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   const colorMode = useColorMode()
-  const route = useRoute()
 
   const isDark = computed({
     get() {
@@ -15,28 +14,23 @@
   const isLoggedIn = computed(() => !!session.value)
   const userRole = computed(() => session.value?.user?.role)
 
-  const navLinks = computed(() => {
+  const navItems = computed(() => {
     if (!isLoggedIn.value) return []
-    const links = [
+    const items = [
       { to: '/locations', label: 'Locations', icon: 'i-heroicons-map-pin-20-solid' },
       { to: '/items', label: 'Items', icon: 'i-heroicons-cube-20-solid' },
     ]
     if (userRole.value === 'admin' || userRole.value === 'supervisor') {
-      links.push({
+      items.push({
         to: '/checkouts',
         label: 'Checkouts',
         icon: 'i-heroicons-clipboard-document-list-20-solid',
       })
-      links.push({ to: '/users', label: 'Users', icon: 'i-heroicons-users-20-solid' })
+      items.push({ to: '/users', label: 'Users', icon: 'i-heroicons-users-20-solid' })
     }
-    links.push({ to: '/profile', label: 'Profile', icon: 'i-heroicons-user-circle-20-solid' })
-    return links
+    items.push({ to: '/profile', label: 'Profile', icon: 'i-heroicons-user-circle-20-solid' })
+    return items
   })
-
-  function isActive(path: string) {
-    if (path === '/') return route.path === '/'
-    return route.path.startsWith(path)
-  }
 </script>
 
 <template>
@@ -44,45 +38,36 @@
     <div
       class="flex min-h-screen flex-col bg-white text-gray-900 transition-colors duration-300 dark:bg-gray-900 dark:text-gray-100"
     >
-      <header
-        class="sticky top-0 z-50 border-b border-gray-200 bg-white/75 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/75"
-      >
-        <UContainer class="flex h-16 items-center justify-between">
-          <div class="flex items-center gap-6">
-            <NuxtLink to="/" class="flex items-center gap-2 text-xl font-bold">
-              <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-8 w-8" />
-              <span>TWC Inventory</span>
-            </NuxtLink>
+      <UHeader title="TWC Inventory" to="/" mode="slideover">
+        <template #title>
+          <UIcon name="i-heroicons-cube-transparent" class="text-primary-500 h-7 w-7" />
+          <span>TWC Inventory</span>
+        </template>
 
-            <nav v-if="isLoggedIn" class="hidden items-center gap-1 md:flex">
-              <NuxtLink
-                v-for="link in navLinks"
-                :key="link.to"
-                :to="link.to"
-                class="flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors"
-                :class="
-                  isActive(link.to)
-                    ? 'bg-primary-50 text-primary-600 dark:bg-primary-950 dark:text-primary-400'
-                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'
-                "
-              >
-                <UIcon :name="link.icon" class="h-4 w-4" />
-                {{ link.label }}
-              </NuxtLink>
-            </nav>
-          </div>
+        <!-- Desktop nav (center slot, visible lg+) -->
+        <UNavigationMenu v-if="isLoggedIn" :items="navItems" highlight />
 
-          <div class="flex items-center gap-2">
-            <UButton
-              :icon="isDark ? 'i-heroicons-moon-20-solid' : 'i-heroicons-sun-20-solid'"
-              color="neutral"
-              variant="ghost"
-              aria-label="Toggle Theme"
-              @click="isDark = !isDark"
-            />
-          </div>
-        </UContainer>
-      </header>
+        <!-- Right side (theme toggle) -->
+        <template #right>
+          <UButton
+            :icon="isDark ? 'i-heroicons-moon-20-solid' : 'i-heroicons-sun-20-solid'"
+            color="neutral"
+            variant="ghost"
+            aria-label="Toggle Theme"
+            @click="isDark = !isDark"
+          />
+        </template>
+
+        <!-- Mobile menu (inside slideover) -->
+        <template #body>
+          <UNavigationMenu
+            v-if="isLoggedIn"
+            :items="navItems"
+            orientation="vertical"
+            class="-mx-2.5"
+          />
+        </template>
+      </UHeader>
 
       <main class="flex-1">
         <NuxtPage />

--- a/app/pages/checkouts/index.vue
+++ b/app/pages/checkouts/index.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+  interface OpenCheckout {
+    id: string
+    item: { id: string; name: string; condition: string }
+    user: { id: string; name: string }
+    checkedOutBy: { id: string; name: string }
+    checkedOutFromLocation: { id: string; name: string }
+    checkedOutAt: string
+    daysOut: number
+  }
+
+  interface OpenCheckoutsResponse {
+    checkouts: OpenCheckout[]
+    total: number
+  }
+
+  const { data: session } = await authClient.useSession(useFetch)
+  const userRole = computed(() => session.value?.user?.role)
+
+  // Redirect non-admin/supervisor to home
+  if (userRole.value !== 'admin' && userRole.value !== 'supervisor') {
+    await navigateTo('/')
+  }
+
+  // Filters
+  const locationFilter = ref<string>('all')
+
+  const { data: locations } = await useFetch('/api/locations')
+
+  const locationOptions = computed(() => {
+    const opts = [{ label: 'All locations', value: 'all' }]
+    if (locations.value) {
+      for (const loc of locations.value) {
+        opts.push({ label: loc.name, value: loc.id })
+      }
+    }
+    return opts
+  })
+
+  const fetchQuery = computed(() => {
+    const q: Record<string, string> = {}
+    if (locationFilter.value && locationFilter.value !== 'all') q.locationId = locationFilter.value
+    return q
+  })
+
+  const { data, pending, error } = await useFetch<OpenCheckoutsResponse>('/api/checkouts/open', {
+    query: fetchQuery,
+  })
+
+  const checkouts = computed(() => data.value?.checkouts ?? [])
+  const total = computed(() => data.value?.total ?? 0)
+
+  function daysOutBadgeColor(days: number) {
+    if (days <= 7) return 'success' as const
+    if (days <= 30) return 'warning' as const
+    return 'error' as const
+  }
+
+  function conditionBadgeColor(condition: string) {
+    if (condition === 'good') return 'success' as const
+    if (condition === 'fair') return 'warning' as const
+    if (condition === 'damaged') return 'error' as const
+    return 'neutral' as const
+  }
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  }
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div class="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Open Checkouts
+        </h1>
+        <p class="mt-1 text-gray-500 dark:text-gray-400">
+          Currently checked-out items across all locations.
+        </p>
+      </div>
+      <div v-if="total > 0" class="text-sm text-gray-500 dark:text-gray-400">
+        {{ total }} item{{ total === 1 ? '' : 's' }} checked out
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center">
+      <USelect v-model="locationFilter" :items="locationOptions" class="w-full md:w-52" />
+    </div>
+
+    <!-- Loading -->
+    <UCard v-if="pending">
+      <div class="space-y-3">
+        <USkeleton class="h-16 w-full" />
+        <USkeleton class="h-16 w-full" />
+        <USkeleton class="h-16 w-full" />
+      </div>
+    </UCard>
+
+    <!-- Error -->
+    <UAlert
+      v-else-if="error"
+      icon="i-heroicons-exclamation-triangle-20-solid"
+      color="error"
+      variant="subtle"
+      title="Error loading checkouts"
+      :description="error.message"
+    />
+
+    <!-- Empty -->
+    <UCard v-else-if="!checkouts.length">
+      <div class="py-12 text-center">
+        <UIcon
+          name="i-heroicons-check-circle-20-solid"
+          class="mx-auto mb-4 h-12 w-12 text-green-400"
+        />
+        <h3 class="text-lg font-medium text-gray-900 dark:text-white">All clear</h3>
+        <p class="mt-1 text-gray-500 dark:text-gray-400">No items are currently checked out.</p>
+      </div>
+    </UCard>
+
+    <!-- Checkout list -->
+    <div v-else class="space-y-3">
+      <NuxtLink
+        v-for="checkout in checkouts"
+        :key="checkout.id"
+        :to="`/items/${checkout.item.id}`"
+        class="block"
+      >
+        <UCard class="transition-shadow hover:shadow-md">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <span class="truncate font-medium text-gray-900 dark:text-white">
+                  {{ checkout.item.name }}
+                </span>
+                <UBadge
+                  :color="conditionBadgeColor(checkout.item.condition)"
+                  variant="subtle"
+                  size="sm"
+                >
+                  {{ checkout.item.condition }}
+                </UBadge>
+              </div>
+              <div class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Held by
+                <span class="font-medium text-gray-700 dark:text-gray-300">
+                  {{ checkout.user.name }}
+                </span>
+                &mdash; checked out by {{ checkout.checkedOutBy.name }} from
+                {{ checkout.checkedOutFromLocation.name }}
+              </div>
+              <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                {{ formatDate(checkout.checkedOutAt) }}
+              </div>
+            </div>
+            <div class="flex items-center gap-2 md:flex-shrink-0">
+              <UBadge :color="daysOutBadgeColor(checkout.daysOut)" variant="subtle" size="sm">
+                {{ checkout.daysOut }} day{{ checkout.daysOut === 1 ? '' : 's' }} out
+              </UBadge>
+            </div>
+          </div>
+        </UCard>
+      </NuxtLink>
+    </div>
+  </UContainer>
+</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,10 +1,47 @@
 <script setup lang="ts">
+  interface DashboardData {
+    stats: {
+      totalItems: number
+      checkedOut: number
+      damaged: number
+      locations: number
+    }
+    openCheckouts: {
+      id: string
+      item: { id: string; name: string }
+      user: { id: string; name: string }
+      checkedOutFromLocation: { id: string; name: string }
+      checkedOutAt: string
+      daysOut: number
+    }[]
+    myItems: {
+      id: string
+      item: { id: string; name: string }
+      checkedOutFromLocation: { id: string; name: string }
+      checkedOutAt: string
+    }[]
+  }
+
   const { data: session } = await authClient.useSession(useFetch)
   const { data: me } = await useFetch('/api/users/me')
+  const { data: dashboard, pending } = await useFetch<DashboardData>('/api/dashboard')
 
   const isAdminOrSupervisor = computed(
     () => session.value?.user?.role === 'admin' || session.value?.user?.role === 'supervisor'
   )
+
+  function daysOutBadgeColor(days: number) {
+    if (days <= 7) return 'success' as const
+    if (days <= 30) return 'warning' as const
+    return 'error' as const
+  }
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    })
+  }
 </script>
 
 <template>
@@ -16,42 +53,168 @@
       </p>
     </div>
 
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <NuxtLink to="/locations">
-        <UCard class="transition-shadow hover:shadow-md">
-          <div class="flex items-center gap-3">
-            <UIcon name="i-heroicons-map-pin-20-solid" class="text-primary-500 h-8 w-8" />
-            <div>
-              <p class="font-semibold text-gray-900 dark:text-white">Locations</p>
-              <p class="text-sm text-gray-500 dark:text-gray-400">View equipment locations</p>
-            </div>
-          </div>
-        </UCard>
-      </NuxtLink>
-
-      <NuxtLink v-if="isAdminOrSupervisor" to="/users">
-        <UCard class="transition-shadow hover:shadow-md">
-          <div class="flex items-center gap-3">
-            <UIcon name="i-heroicons-users-20-solid" class="text-primary-500 h-8 w-8" />
-            <div>
-              <p class="font-semibold text-gray-900 dark:text-white">Users</p>
-              <p class="text-sm text-gray-500 dark:text-gray-400">Manage team members</p>
-            </div>
-          </div>
-        </UCard>
-      </NuxtLink>
-
-      <NuxtLink to="/profile">
-        <UCard class="transition-shadow hover:shadow-md">
-          <div class="flex items-center gap-3">
-            <UIcon name="i-heroicons-user-circle-20-solid" class="text-primary-500 h-8 w-8" />
-            <div>
-              <p class="font-semibold text-gray-900 dark:text-white">Profile</p>
-              <p class="text-sm text-gray-500 dark:text-gray-400">View your account</p>
-            </div>
-          </div>
-        </UCard>
-      </NuxtLink>
+    <!-- Loading -->
+    <div v-if="pending" class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <UCard v-for="i in 4" :key="i">
+        <USkeleton class="h-8 w-16" />
+        <USkeleton class="mt-2 h-4 w-24" />
+      </UCard>
     </div>
+
+    <template v-else-if="dashboard">
+      <!-- Stats -->
+      <div class="mb-8 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <NuxtLink to="/items">
+          <UCard class="transition-shadow hover:shadow-md">
+            <div class="flex items-center gap-3">
+              <div class="bg-primary-50 dark:bg-primary-950 rounded-lg p-2.5">
+                <UIcon name="i-heroicons-cube-20-solid" class="text-primary-500 h-6 w-6" />
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                  {{ dashboard.stats.totalItems }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Total Items</p>
+              </div>
+            </div>
+          </UCard>
+        </NuxtLink>
+
+        <NuxtLink :to="isAdminOrSupervisor ? '/checkouts' : '/items'">
+          <UCard class="transition-shadow hover:shadow-md">
+            <div class="flex items-center gap-3">
+              <div class="rounded-lg bg-amber-50 p-2.5 dark:bg-amber-950">
+                <UIcon
+                  name="i-heroicons-arrow-right-circle-20-solid"
+                  class="h-6 w-6 text-amber-500"
+                />
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                  {{ dashboard.stats.checkedOut }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Checked Out</p>
+              </div>
+            </div>
+          </UCard>
+        </NuxtLink>
+
+        <NuxtLink to="/items">
+          <UCard class="transition-shadow hover:shadow-md">
+            <div class="flex items-center gap-3">
+              <div class="rounded-lg bg-red-50 p-2.5 dark:bg-red-950">
+                <UIcon
+                  name="i-heroicons-exclamation-triangle-20-solid"
+                  class="h-6 w-6 text-red-500"
+                />
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                  {{ dashboard.stats.damaged }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Damaged</p>
+              </div>
+            </div>
+          </UCard>
+        </NuxtLink>
+
+        <NuxtLink to="/locations">
+          <UCard class="transition-shadow hover:shadow-md">
+            <div class="flex items-center gap-3">
+              <div class="rounded-lg bg-green-50 p-2.5 dark:bg-green-950">
+                <UIcon name="i-heroicons-map-pin-20-solid" class="h-6 w-6 text-green-500" />
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                  {{ dashboard.stats.locations }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Locations</p>
+              </div>
+            </div>
+          </UCard>
+        </NuxtLink>
+      </div>
+
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <!-- My Items (all users) -->
+        <UCard>
+          <template #header>
+            <div class="flex items-center gap-2">
+              <UIcon name="i-heroicons-cube-20-solid" class="h-5 w-5 text-gray-500" />
+              <h2 class="text-base font-semibold text-gray-900 dark:text-white">My Items</h2>
+            </div>
+          </template>
+          <div v-if="!dashboard.myItems.length" class="py-4 text-center text-gray-500">
+            You don't have any items checked out.
+          </div>
+          <div v-else class="space-y-3">
+            <NuxtLink
+              v-for="checkout in dashboard.myItems"
+              :key="checkout.id"
+              :to="`/items/${checkout.item.id}`"
+              class="block rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+            >
+              <div class="flex items-center justify-between">
+                <span class="font-medium text-gray-900 dark:text-white">
+                  {{ checkout.item.name }}
+                </span>
+                <span class="text-xs text-gray-400">
+                  {{ formatDate(checkout.checkedOutAt) }}
+                </span>
+              </div>
+              <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                From {{ checkout.checkedOutFromLocation.name }}
+              </p>
+            </NuxtLink>
+          </div>
+        </UCard>
+
+        <!-- Open Checkouts (admin/supervisor) -->
+        <UCard v-if="isAdminOrSupervisor">
+          <template #header>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <UIcon
+                  name="i-heroicons-clipboard-document-list-20-solid"
+                  class="h-5 w-5 text-gray-500"
+                />
+                <h2 class="text-base font-semibold text-gray-900 dark:text-white">
+                  Recent Open Checkouts
+                </h2>
+              </div>
+              <NuxtLink
+                to="/checkouts"
+                class="text-primary-500 text-sm font-medium hover:underline"
+              >
+                View all
+              </NuxtLink>
+            </div>
+          </template>
+          <div v-if="!dashboard.openCheckouts.length" class="py-4 text-center text-gray-500">
+            No items are currently checked out.
+          </div>
+          <div v-else class="space-y-3">
+            <NuxtLink
+              v-for="checkout in dashboard.openCheckouts"
+              :key="checkout.id"
+              :to="`/items/${checkout.item.id}`"
+              class="block rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+            >
+              <div class="flex items-center justify-between">
+                <span class="font-medium text-gray-900 dark:text-white">
+                  {{ checkout.item.name }}
+                </span>
+                <UBadge :color="daysOutBadgeColor(checkout.daysOut)" variant="subtle" size="sm">
+                  {{ checkout.daysOut }}d
+                </UBadge>
+              </div>
+              <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                {{ checkout.user.name }} &mdash; from {{ checkout.checkedOutFromLocation.name }}
+              </p>
+            </NuxtLink>
+          </div>
+        </UCard>
+      </div>
+    </template>
   </UContainer>
 </template>

--- a/app/pages/items/[id].vue
+++ b/app/pages/items/[id].vue
@@ -46,6 +46,28 @@
 
   const { data: item, pending, error, refresh } = await useFetch<ItemDetail>(`/api/items/${id}`)
 
+  // Full history (lazy-loaded on demand)
+  type HistoryEntry = ItemDetail['recentHistory'][number]
+  const showFullHistory = ref(false)
+  const {
+    data: fullHistory,
+    pending: historyPending,
+    execute: loadFullHistory,
+  } = await useFetch<HistoryEntry[]>(`/api/items/${id}/history`, {
+    immediate: false,
+    watch: false,
+  })
+
+  async function viewAllHistory() {
+    showFullHistory.value = true
+    await loadFullHistory()
+  }
+
+  const displayedHistory = computed(() => {
+    if (showFullHistory.value && fullHistory.value) return fullHistory.value
+    return item.value?.recentHistory ?? []
+  })
+
   // Fetch locations for edit form
   const { data: locations } = await useFetch('/api/locations')
 
@@ -446,12 +468,20 @@
             <h2 class="text-base font-semibold text-gray-900 dark:text-white">Checkout History</h2>
           </div>
         </template>
-        <div v-if="!item.recentHistory.length" class="py-6 text-center text-gray-500">
+        <div
+          v-if="!displayedHistory.length && !historyPending"
+          class="py-6 text-center text-gray-500"
+        >
           No checkout history yet.
+        </div>
+        <div v-else-if="historyPending" class="space-y-3">
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
         </div>
         <div v-else class="space-y-3">
           <div
-            v-for="log in item.recentHistory"
+            v-for="log in displayedHistory"
             :key="log.id"
             class="rounded-lg border p-3"
             :class="
@@ -482,6 +512,16 @@
                 </template>
               </template>
             </div>
+          </div>
+          <div v-if="!showFullHistory && item.recentHistory.length >= 10" class="pt-2 text-center">
+            <UButton
+              variant="soft"
+              color="neutral"
+              size="sm"
+              label="View all history"
+              icon="i-heroicons-clock-20-solid"
+              @click="viewAllHistory"
+            />
           </div>
         </div>
       </UCard>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -43,6 +43,50 @@
     }
   }
 
+  // Checkout history
+  interface HistoryEntry {
+    id: string
+    item: { id: string; name: string }
+    checkedOutBy: { id: string; name: string }
+    checkedOutFromLocation: { id: string; name: string }
+    checkedOutAt: string
+    checkedInBy: { id: string; name: string } | null
+    checkedInAtLocation: { id: string; name: string } | null
+    checkedInAt: string | null
+    conditionOnReturn: string | null
+    isOpen: boolean
+  }
+
+  const {
+    data: history,
+    pending: historyPending,
+    execute: loadHistory,
+  } = await useFetch<HistoryEntry[]>(() => `/api/users/${user.value?.id}/history`, {
+    immediate: false,
+    watch: false,
+  })
+
+  watch(
+    user,
+    (val) => {
+      if (val?.id) loadHistory()
+    },
+    { immediate: true }
+  )
+
+  const currentlyHolding = computed(() => (history.value ?? []).filter((log) => log.isOpen))
+  const pastCheckouts = computed(() => (history.value ?? []).filter((log) => !log.isOpen))
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  }
+
   async function logout() {
     await authClient.signOut()
     await navigateTo('/auth', { external: true })
@@ -152,6 +196,103 @@
                   {{ user.preferredFirstName || user.legalFirstName }}
                   {{ user.preferredLastName || user.legalLastName }}
                 </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </UCard>
+      <!-- Checkout History -->
+      <UCard class="mt-6">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-heroicons-clipboard-document-list-20-solid"
+              class="h-5 w-5 text-gray-500"
+            />
+            <h2 class="text-base font-semibold text-gray-900 dark:text-white">
+              My Checkout History
+            </h2>
+          </div>
+        </template>
+        <div v-if="!history?.length && !historyPending" class="py-6 text-center text-gray-500">
+          No checkout history yet.
+        </div>
+        <div v-else-if="historyPending" class="space-y-3">
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
+        </div>
+        <div v-else class="space-y-4">
+          <!-- Currently Holding -->
+          <div v-if="currentlyHolding.length">
+            <p
+              class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+            >
+              Currently Holding
+            </p>
+            <div class="space-y-3">
+              <div
+                v-for="log in currentlyHolding"
+                :key="log.id"
+                class="border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-950 rounded-lg border p-3"
+              >
+                <div class="flex items-center justify-between">
+                  <div class="text-sm">
+                    <NuxtLink
+                      :to="`/items/${log.item.id}`"
+                      class="text-primary-500 font-medium hover:underline"
+                    >
+                      {{ log.item.name }}
+                    </NuxtLink>
+                    <span class="text-gray-500 dark:text-gray-400">
+                      &mdash; checked out by {{ log.checkedOutBy.name }} from
+                      {{ log.checkedOutFromLocation.name }}
+                    </span>
+                  </div>
+                  <UBadge color="warning" variant="subtle" size="sm"> open </UBadge>
+                </div>
+                <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Out: {{ formatDate(log.checkedOutAt) }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Past Checkouts -->
+          <div v-if="pastCheckouts.length">
+            <p
+              class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+            >
+              Past Checkouts
+            </p>
+            <div class="space-y-3">
+              <div
+                v-for="log in pastCheckouts"
+                :key="log.id"
+                class="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+              >
+                <div class="text-sm">
+                  <NuxtLink
+                    :to="`/items/${log.item.id}`"
+                    class="text-primary-500 font-medium hover:underline"
+                  >
+                    {{ log.item.name }}
+                  </NuxtLink>
+                  <span class="text-gray-500 dark:text-gray-400">
+                    &mdash; checked out by {{ log.checkedOutBy.name }} from
+                    {{ log.checkedOutFromLocation.name }}
+                  </span>
+                </div>
+                <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Out: {{ formatDate(log.checkedOutAt) }}
+                  <template v-if="log.checkedInAt">
+                    &bull; In: {{ formatDate(log.checkedInAt) }} at
+                    {{ log.checkedInAtLocation?.name }} by {{ log.checkedInBy?.name }}
+                    <template v-if="log.conditionOnReturn">
+                      &bull; Condition: {{ log.conditionOnReturn }}
+                    </template>
+                  </template>
+                </div>
               </div>
             </div>
           </div>

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -39,6 +39,31 @@
 
   const { data: user, pending, error, refresh } = await useFetch<UserDetail>(`/api/users/${id}`)
 
+  // Full history (lazy-loaded on demand)
+  type HistoryEntry = UserDetail['checkoutHistory'][number]
+  const showFullHistory = ref(false)
+  const {
+    data: fullHistory,
+    pending: historyPending,
+    execute: loadFullHistory,
+  } = await useFetch<HistoryEntry[]>(`/api/users/${id}/history`, {
+    immediate: false,
+    watch: false,
+  })
+
+  async function viewAllHistory() {
+    showFullHistory.value = true
+    await loadFullHistory()
+  }
+
+  const displayedHistory = computed(() => {
+    if (showFullHistory.value && fullHistory.value) return fullHistory.value
+    return user.value?.checkoutHistory ?? []
+  })
+
+  const currentlyHolding = computed(() => displayedHistory.value.filter((log) => log.isOpen))
+  const pastCheckouts = computed(() => displayedHistory.value.filter((log) => !log.isOpen))
+
   // Edit modal
   const isEditOpen = ref(false)
   const isSubmitting = ref(false)
@@ -235,45 +260,104 @@
             <h2 class="text-base font-semibold text-gray-900 dark:text-white">Checkout History</h2>
           </div>
         </template>
-        <div v-if="!user.checkoutHistory.length" class="py-6 text-center text-gray-500">
+        <div
+          v-if="!displayedHistory.length && !historyPending"
+          class="py-6 text-center text-gray-500"
+        >
           No checkout history yet.
         </div>
-        <div v-else class="space-y-3">
-          <div
-            v-for="log in user.checkoutHistory"
-            :key="log.id"
-            class="rounded-lg border p-3"
-            :class="
-              log.isOpen
-                ? 'border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-950'
-                : 'border-gray-200 dark:border-gray-700'
-            "
-          >
-            <div class="flex items-center justify-between">
-              <div class="text-sm">
-                <NuxtLink
-                  :to="`/items/${log.item.id}`"
-                  class="text-primary-500 font-medium hover:underline"
-                >
-                  {{ log.item.name }}
-                </NuxtLink>
-                <span class="text-gray-500 dark:text-gray-400">
-                  &mdash; checked out by {{ log.checkedOutBy.name }} from
-                  {{ log.checkedOutFromLocation.name }}
-                </span>
+        <div v-else-if="historyPending" class="space-y-3">
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
+          <USkeleton class="h-16 w-full" />
+        </div>
+        <div v-else class="space-y-4">
+          <!-- Currently Holding -->
+          <div v-if="currentlyHolding.length">
+            <p
+              class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+            >
+              Currently Holding
+            </p>
+            <div class="space-y-3">
+              <div
+                v-for="log in currentlyHolding"
+                :key="log.id"
+                class="border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-950 rounded-lg border p-3"
+              >
+                <div class="flex items-center justify-between">
+                  <div class="text-sm">
+                    <NuxtLink
+                      :to="`/items/${log.item.id}`"
+                      class="text-primary-500 font-medium hover:underline"
+                    >
+                      {{ log.item.name }}
+                    </NuxtLink>
+                    <span class="text-gray-500 dark:text-gray-400">
+                      &mdash; checked out by {{ log.checkedOutBy.name }} from
+                      {{ log.checkedOutFromLocation.name }}
+                    </span>
+                  </div>
+                  <UBadge color="warning" variant="subtle" size="sm"> open </UBadge>
+                </div>
+                <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Out: {{ formatDate(log.checkedOutAt) }}
+                </div>
               </div>
-              <UBadge v-if="log.isOpen" color="warning" variant="subtle" size="sm"> open </UBadge>
             </div>
-            <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-              Out: {{ formatDate(log.checkedOutAt) }}
-              <template v-if="log.checkedInAt">
-                &bull; In: {{ formatDate(log.checkedInAt) }} at
-                {{ log.checkedInAtLocation?.name }} by {{ log.checkedInBy?.name }}
-                <template v-if="log.conditionOnReturn">
-                  &bull; Condition: {{ log.conditionOnReturn }}
-                </template>
-              </template>
+          </div>
+
+          <!-- Past Checkouts -->
+          <div v-if="pastCheckouts.length">
+            <p
+              class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+            >
+              Past Checkouts
+            </p>
+            <div class="space-y-3">
+              <div
+                v-for="log in pastCheckouts"
+                :key="log.id"
+                class="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+              >
+                <div class="text-sm">
+                  <NuxtLink
+                    :to="`/items/${log.item.id}`"
+                    class="text-primary-500 font-medium hover:underline"
+                  >
+                    {{ log.item.name }}
+                  </NuxtLink>
+                  <span class="text-gray-500 dark:text-gray-400">
+                    &mdash; checked out by {{ log.checkedOutBy.name }} from
+                    {{ log.checkedOutFromLocation.name }}
+                  </span>
+                </div>
+                <div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Out: {{ formatDate(log.checkedOutAt) }}
+                  <template v-if="log.checkedInAt">
+                    &bull; In: {{ formatDate(log.checkedInAt) }} at
+                    {{ log.checkedInAtLocation?.name }} by {{ log.checkedInBy?.name }}
+                    <template v-if="log.conditionOnReturn">
+                      &bull; Condition: {{ log.conditionOnReturn }}
+                    </template>
+                  </template>
+                </div>
+              </div>
             </div>
+          </div>
+
+          <div
+            v-if="!showFullHistory && user.checkoutHistory.length >= 10"
+            class="pt-2 text-center"
+          >
+            <UButton
+              variant="soft"
+              color="neutral"
+              size="sm"
+              label="View all history"
+              icon="i-heroicons-clock-20-solid"
+              @click="viewAllHistory"
+            />
           </div>
         </div>
       </UCard>

--- a/docs/features/check-in-out.md
+++ b/docs/features/check-in-out.md
@@ -6,17 +6,18 @@ The check-in/check-out system is how equipment moves between locations and peopl
 
 ## Permissions
 
-| Action | Admin | Supervisor | Employee |
-|---|---|---|---|
-| Check out item to someone | Yes | Yes | No |
-| Check out item to self | Yes | Yes | No |
-| Check in item | Yes | Yes | No |
-| View own checkout history | Yes | Yes | Yes |
-| View all checkout history | Yes | Yes | No |
+| Action                    | Admin | Supervisor | Employee |
+| ------------------------- | ----- | ---------- | -------- |
+| Check out item to someone | Yes   | Yes        | No       |
+| Check out item to self    | Yes   | Yes        | No       |
+| Check in item             | Yes   | Yes        | No       |
+| View own checkout history | Yes   | Yes        | Yes      |
+| View all checkout history | Yes   | Yes        | No       |
 
 ## Check-out Flow
 
 ### Trigger Points
+
 - Item detail page: "Check Out" button (visible to admin/supervisor when item status is `available`)
 - QR code scan: scan item → item detail page → "Check Out"
 
@@ -44,6 +45,7 @@ The check-in/check-out system is how equipment moves between locations and peopl
 ## Check-in Flow
 
 ### Trigger Points
+
 - Item detail page: "Check In" button (visible to admin/supervisor when item status is `checked_out`)
 - QR code scan: scan item → item detail page → "Check In"
 
@@ -77,18 +79,23 @@ Every check-out creates a row. Every check-in completes that row. This gives a c
 ### Queryable Views
 
 **Item history** — "Where has this item been?"
+
 - Query: `CheckoutLog WHERE itemId = X ORDER BY checkedOutAt DESC`
 - Shows: each checkout/check-in cycle with who, when, where, condition
 
 **User history** — "What has this person checked out?"
+
 - Query: `CheckoutLog WHERE userId = X ORDER BY checkedOutAt DESC`
 - Shows: all items the person has had, when, current status
 
 **Open checkouts** — "What's currently checked out?"
+
 - Query: `CheckoutLog WHERE checkedInAt IS NULL`
-- Shows: all items currently with someone, useful for admin dashboard
+- Shows: all items currently with someone
+- **Dashboard page**: `/checkouts` (admin/supervisor only) with location filter, days-out badges (green ≤7d, yellow 8–30d, red >30d), and total count
 
 **Location activity** — "What's moved through this location?"
+
 - Query: `CheckoutLog WHERE checkedOutFromLocationId = X OR checkedInAtLocationId = X`
 
 ## Edge Cases
@@ -101,10 +108,10 @@ Every check-out creates a row. Every check-in completes that row. This gives a c
 
 ## API Routes
 
-| Method | Route | Description | Role |
-|---|---|---|---|
-| POST | `/api/items/[id]/checkout` | Check out an item | Admin, Supervisor |
-| POST | `/api/items/[id]/checkin` | Check in an item | Admin, Supervisor |
-| GET | `/api/items/[id]/history` | Item's checkout history | All |
-| GET | `/api/users/[id]/history` | User's checkout history | Admin, Supervisor (own history: all) |
-| GET | `/api/checkouts/open` | All currently checked-out items | Admin, Supervisor |
+| Method | Route                      | Description                     | Role                                 |
+| ------ | -------------------------- | ------------------------------- | ------------------------------------ |
+| POST   | `/api/items/[id]/checkout` | Check out an item               | Admin, Supervisor                    |
+| POST   | `/api/items/[id]/checkin`  | Check in an item                | Admin, Supervisor                    |
+| GET    | `/api/items/[id]/history`  | Item's checkout history         | All                                  |
+| GET    | `/api/users/[id]/history`  | User's checkout history         | Admin, Supervisor (own history: all) |
+| GET    | `/api/checkouts/open`      | All currently checked-out items | Admin, Supervisor                    |

--- a/docs/features/items.md
+++ b/docs/features/items.md
@@ -46,7 +46,7 @@ Displays:
 - Item name, description, condition badge, status badge
 - Home location and current location
 - QR code (with print button)
-- Checkout history (from CheckoutLog)
+- Checkout history (recent 10 from CheckoutLog, with "View all history" button for lazy-loaded full history)
 - If admin: edit/delete buttons
 - If admin/supervisor and item is available: "Check Out" button
 - If admin/supervisor and item is checked out: "Check In" button with current holder info

--- a/docs/features/users.md
+++ b/docs/features/users.md
@@ -77,7 +77,8 @@ Displays:
 - Legal name and preferred name (if different)
 - Email, role, status
 - Profile picture (existing feature)
-- Checkout history placeholder (will show items once check-in/out is implemented in #7-#9)
+- Checkout history split into "Currently Holding" (open checkouts, highlighted) and "Past Checkouts" (completed, newest first)
+- Lazy-loaded full history via "View all history" button when 10+ records
 - Admin: edit button, role/status controls (set to `inactive` to deactivate)
 
 ### Create User Form
@@ -106,15 +107,16 @@ Employees can view their own profile at `/profile`:
 
 - See their name, email, role, status
 - Upload/change profile picture
+- Checkout history split into "Currently Holding" and "Past Checkouts" (fetched from `/api/users/[id]/history`)
 - Logout button
 
 ## API Routes
 
-| Method | Route                     | Description                                            | Role                              |
-| ------ | ------------------------- | ------------------------------------------------------ | --------------------------------- |
-| GET    | `/api/users`              | List all users                                         | Admin, Supervisor                 |
-| GET    | `/api/users/[id]`         | Get user detail                                        | Admin, Supervisor, or own profile |
-| POST   | `/api/users`              | Create user                                            | Admin                             |
-| PUT    | `/api/users/[id]`         | Update user                                            | Admin                             |
-| GET    | `/api/users/me`           | Get current user's profile                             | All                               |
-| GET    | `/api/users/[id]/history` | User's checkout history (not yet implemented — see #9) | Admin, Supervisor, or own history |
+| Method | Route                     | Description                | Role                              |
+| ------ | ------------------------- | -------------------------- | --------------------------------- |
+| GET    | `/api/users`              | List all users             | Admin, Supervisor                 |
+| GET    | `/api/users/[id]`         | Get user detail            | Admin, Supervisor, or own profile |
+| POST   | `/api/users`              | Create user                | Admin                             |
+| PUT    | `/api/users/[id]`         | Update user                | Admin                             |
+| GET    | `/api/users/me`           | Get current user's profile | All                               |
+| GET    | `/api/users/[id]/history` | User's checkout history    | Admin, Supervisor, or own history |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,17 +16,18 @@ An inventory management application for **The Warren Center** (TWC), a pediatric
 
 All ~100 TWC employees will have accounts. Three roles control what they can do:
 
-| Role | Can do |
-|---|---|
-| **Admin** | CRUD locations, items, users. Check in/out items. Full access. |
-| **Supervisor** | Check in/out items (for self and others). View everything. |
-| **Employee** | View items and their own checkout history. Items can be checked in/out *for* them by admin/supervisor. |
+| Role           | Can do                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------ |
+| **Admin**      | CRUD locations, items, users. Check in/out items. Full access.                                         |
+| **Supervisor** | Check in/out items (for self and others). View everything.                                             |
+| **Employee**   | View items and their own checkout history. Items can be checked in/out _for_ them by admin/supervisor. |
 
 Initial admins: Brandy Lindsey, Isabel Saenz, Tushar Wani.
 
 ## Core Features
 
 ### Item Management (Admin only)
+
 - Create, read, update, delete items
 - Each item gets a unique QR code generated at creation
 - QR codes are printable in multiple label sizes
@@ -34,26 +35,37 @@ Initial admins: Brandy Lindsey, Isabel Saenz, Tushar Wani.
 - Condition tracking: good, fair, damaged, retired (all transitions allowed)
 
 ### Check-in / Check-out (Admin + Supervisor)
+
 - Check out an item from a location to a person
 - Check in an item at any location (does not have to match where it was checked out from)
 - Condition must be reported on every check-in
 - Full audit trail: who, when, where, condition
 
 ### Location Management (Admin only)
+
 - CRUD operations on locations
 - Three locations seeded at setup
 
 ### User Management (Admin only)
+
 - CRUD operations on users
 - Assign roles and statuses
 - Users seeded from roster CSV at setup
 
 ### QR Code Scanning (All roles)
+
 - Scanning a QR code opens the item detail page
 - If not logged in, redirect to login, then back to the item page
 - Admin/supervisor see check-in/out actions; employees see read-only detail
 
+### Dashboard (All roles)
+
+- Stats overview: total items, checked out count, damaged count, active locations
+- My Items: items currently checked out to the logged-in user
+- Recent Open Checkouts: oldest open checkouts with days-out indicators (admin/supervisor only)
+
 ### Authentication
+
 - Email OTP via Better Auth
 - Restricted to `@thewarrencenter.org` domain + two specific external emails
 - No unauthenticated access to any data or page

--- a/docs/seed-data.md
+++ b/docs/seed-data.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The seed script (`prisma/seed.ts`) populates the database with locations and users from the employee roster. This runs as part of `pnpm prisma:reset`.
+The seed script (`prisma/seed.ts`) populates the database with locations, users, items, and checkout logs. This runs as part of `pnpm prisma:reset`.
 
 ## Locations
 
@@ -31,14 +31,14 @@ const locations = [
 
 `roster.csv` at the project root. 100 rows with columns:
 
-| CSV Column | Maps To |
-|---|---|
-| Legal Name | Parsed into `legalFirstName` + `legalLastName` |
-| Preferred or Chosen First Name | `preferredFirstName` (nullable) |
-| Preferred or Chosen Last Name | `preferredLastName` (nullable) |
-| Work Contact: Work Email | `email` |
-| Position Status | `status` (`Active` → `active`, `Leave` → `on_leave`) |
-| Job Title Description | Not stored (informational only, for now) |
+| CSV Column                     | Maps To                                              |
+| ------------------------------ | ---------------------------------------------------- |
+| Legal Name                     | Parsed into `legalFirstName` + `legalLastName`       |
+| Preferred or Chosen First Name | `preferredFirstName` (nullable)                      |
+| Preferred or Chosen Last Name  | `preferredLastName` (nullable)                       |
+| Work Contact: Work Email       | `email`                                              |
+| Position Status                | `status` (`Active` → `active`, `Leave` → `on_leave`) |
+| Job Title Description          | Not stored (informational only, for now)             |
 
 ### Parsing Legal Name
 
@@ -48,7 +48,7 @@ The CSV stores legal name as `"LastName, FirstName"`. The seed script must split
 // "Abernathy, Christopher" → legalFirstName: "Christopher", legalLastName: "Abernathy"
 // "Hernandez Kilpatrick, Hilda" → legalFirstName: "Hilda", legalLastName: "Hernandez Kilpatrick"
 // "Almeyda Noriega, Irma" → legalFirstName: "Irma", legalLastName: "Almeyda Noriega"
-const [lastName, firstName] = legalName.split(',').map(s => s.trim())
+const [lastName, firstName] = legalName.split(',').map((s) => s.trim())
 ```
 
 ### Display Name Computation
@@ -63,13 +63,13 @@ const name = `${displayFirst} ${displayLast}`
 
 ### Role Assignments
 
-| Email | Role |
-|---|---|
-| `brandy.lindsey@thewarrencenter.org` | `admin` |
-| `isabel.saenz@thewarrencenter.org` | `admin` |
-| `reachtusharwani@gmail.com` | `admin` |
-| `tmw220003@utdallas.edu` | `supervisor` |
-| All other roster emails | `employee` |
+| Email                                | Role         |
+| ------------------------------------ | ------------ |
+| `brandy.lindsey@thewarrencenter.org` | `admin`      |
+| `isabel.saenz@thewarrencenter.org`   | `admin`      |
+| `reachtusharwani@gmail.com`          | `admin`      |
+| `tmw220003@utdallas.edu`             | `supervisor` |
+| All other roster emails              | `employee`   |
 
 Tushar Wani (`reachtusharwani@gmail.com`) is not in the roster CSV and must be added manually in the seed:
 
@@ -98,9 +98,9 @@ The supervisor seed user (`tmw220003@utdallas.edu`):
 ### Status Mapping
 
 | CSV Position Status | User Status |
-|---|---|
-| `Active` | `active` |
-| `Leave` | `on_leave` |
+| ------------------- | ----------- |
+| `Active`            | `active`    |
+| `Leave`             | `on_leave`  |
 
 Currently only Amanda Johnston has `Leave` status in the roster.
 
@@ -123,3 +123,44 @@ Some roster entries have quirks the parser must handle:
 - **Empty preferred name fields**: Most rows have empty preferred names — these become `null`
 - **Email doesn't match name**: Some emails use maiden/preferred names (e.g., `Bobo, Ashlyn` has email `ashlyn.smith@thewarrencenter.org`). The email is authoritative for login; names are for display.
 - **Multi-word last names**: `"Hernandez Kilpatrick, Hilda"`, `"Wilson Martin, Laquasha"` — split only on the first comma
+
+## Items
+
+8 sample items are seeded across the three locations:
+
+| Item                 | Location |
+| -------------------- | -------- |
+| iPad Pro #1          | Central  |
+| iPad Pro #2          | East     |
+| Therapy Ball - Large | Central  |
+| Projector            | West     |
+| Laptop Cart          | East     |
+| First Aid Kit        | Central  |
+| Audio System         | West     |
+| Therapy Swing        | East     |
+
+All items start with condition `good` and status `available`. Existing seed items are deleted and re-created on each run (not upserted) to ensure clean state.
+
+## Checkout Logs
+
+8 checkout logs are seeded to populate the dashboard and history views:
+
+**Open checkouts** (4 items currently checked out):
+
+| Item         | Days Out | Purpose               |
+| ------------ | -------- | --------------------- |
+| iPad Pro #1  | ~3 days  | Green days-out badge  |
+| Laptop Cart  | ~5 days  | Green days-out badge  |
+| Projector    | ~12 days | Yellow days-out badge |
+| Audio System | ~35 days | Red days-out badge    |
+
+**Completed checkouts** (4 returned items):
+
+| Item                    | Notes                                        |
+| ----------------------- | -------------------------------------------- |
+| iPad Pro #2             | Returned in good condition, moved to Central |
+| Therapy Ball - Large    | Returned in fair condition                   |
+| Therapy Swing (cycle 1) | Returned in good condition                   |
+| Therapy Swing (cycle 2) | Returned in good condition, moved to West    |
+
+Checkout performers alternate between the admin (Brandy Lindsey) and supervisor (Isabel Saenz) seed users. Item holders are drawn from the first 6 active employees. All checkout logs are deleted and re-created on each seed run.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -230,6 +230,167 @@ async function main() {
   }
   console.log(`Seeded ${ITEMS.length} items`)
 
+  // 6. Seed checkout logs
+  // Clean up existing seed checkout logs
+  await prisma.checkoutLog.deleteMany({})
+
+  const allItems = await prisma.item.findMany({ select: { id: true, name: true } })
+  const itemByName = Object.fromEntries(allItems.map((i) => [i.name, i.id]))
+
+  // Grab some users to use as holders and performers
+  const adminUser = await prisma.user.findFirst({
+    where: { email: 'brandy.lindsey@thewarrencenter.org' },
+    select: { id: true },
+  })
+  const supervisorUser = await prisma.user.findFirst({
+    where: { email: 'isabel.saenz@thewarrencenter.org' },
+    select: { id: true },
+  })
+  const employees = await prisma.user.findMany({
+    where: { role: 'employee', status: 'active' },
+    select: { id: true },
+    take: 6,
+  })
+
+  if (adminUser && supervisorUser && employees.length >= 6) {
+    const now = Date.now()
+    const day = 86_400_000
+
+    // --- Open checkouts (items currently checked out) ---
+
+    // iPad Pro #1 — checked out 3 days ago (green badge)
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['iPad Pro #1'],
+        userId: employees[0].id,
+        checkedOutBy: adminUser.id,
+        checkedOutFromLocationId: central,
+        checkedOutAt: new Date(now - 3 * day),
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['iPad Pro #1'] },
+      data: { status: 'checked_out' },
+    })
+
+    // Projector — checked out 12 days ago (yellow badge)
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Projector'],
+        userId: employees[1].id,
+        checkedOutBy: supervisorUser.id,
+        checkedOutFromLocationId: west,
+        checkedOutAt: new Date(now - 12 * day),
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['Projector'] },
+      data: { status: 'checked_out' },
+    })
+
+    // Audio System — checked out 35 days ago (red badge)
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Audio System'],
+        userId: employees[2].id,
+        checkedOutBy: adminUser.id,
+        checkedOutFromLocationId: west,
+        checkedOutAt: new Date(now - 35 * day),
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['Audio System'] },
+      data: { status: 'checked_out' },
+    })
+
+    // Laptop Cart — checked out 5 days ago (green badge)
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Laptop Cart'],
+        userId: employees[3].id,
+        checkedOutBy: adminUser.id,
+        checkedOutFromLocationId: east,
+        checkedOutAt: new Date(now - 5 * day),
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['Laptop Cart'] },
+      data: { status: 'checked_out' },
+    })
+
+    // --- Completed checkouts (for history views) ---
+
+    // iPad Pro #2 — was checked out 20 days ago, returned 14 days ago
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['iPad Pro #2'],
+        userId: employees[4].id,
+        checkedOutBy: adminUser.id,
+        checkedOutFromLocationId: east,
+        checkedOutAt: new Date(now - 20 * day),
+        checkedInBy: supervisorUser.id,
+        checkedInAtLocationId: central,
+        checkedInAt: new Date(now - 14 * day),
+        conditionOnReturn: 'good',
+      },
+    })
+
+    // Therapy Ball — was checked out 30 days ago, returned 25 days ago with fair condition
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Therapy Ball - Large'],
+        userId: employees[5].id,
+        checkedOutBy: supervisorUser.id,
+        checkedOutFromLocationId: central,
+        checkedOutAt: new Date(now - 30 * day),
+        checkedInBy: adminUser.id,
+        checkedInAtLocationId: central,
+        checkedInAt: new Date(now - 25 * day),
+        conditionOnReturn: 'fair',
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['Therapy Ball - Large'] },
+      data: { condition: 'fair' },
+    })
+
+    // Therapy Swing — two cycles: checked out 45 days ago, returned 40 days ago, then again 15 days ago, returned 10 days ago
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Therapy Swing'],
+        userId: employees[0].id,
+        checkedOutBy: adminUser.id,
+        checkedOutFromLocationId: east,
+        checkedOutAt: new Date(now - 45 * day),
+        checkedInBy: adminUser.id,
+        checkedInAtLocationId: east,
+        checkedInAt: new Date(now - 40 * day),
+        conditionOnReturn: 'good',
+      },
+    })
+    await prisma.checkoutLog.create({
+      data: {
+        itemId: itemByName['Therapy Swing'],
+        userId: employees[2].id,
+        checkedOutBy: supervisorUser.id,
+        checkedOutFromLocationId: east,
+        checkedOutAt: new Date(now - 15 * day),
+        checkedInBy: adminUser.id,
+        checkedInAtLocationId: west,
+        checkedInAt: new Date(now - 10 * day),
+        conditionOnReturn: 'good',
+      },
+    })
+    await prisma.item.update({
+      where: { id: itemByName['Therapy Swing'] },
+      data: { currentLocationId: west },
+    })
+
+    console.log('Seeded 8 checkout logs (4 open, 4 completed)')
+  } else {
+    console.log('Skipped checkout log seeding (required users not found)')
+  }
+
   console.log('Seeding finished.')
 }
 

--- a/server/api/checkouts/open.get.ts
+++ b/server/api/checkouts/open.get.ts
@@ -1,0 +1,50 @@
+export default defineEventHandler(async (event) => {
+  requireRole(event, 'admin', 'supervisor')
+
+  const query = getQuery(event)
+  const locationId = query.locationId as string | undefined
+  const userId = query.userId as string | undefined
+
+  const where: Record<string, unknown> = { checkedInAt: null }
+  if (locationId) where.checkedOutFromLocationId = locationId
+  if (userId) where.userId = userId
+
+  const [logs, total] = await Promise.all([
+    prisma.checkoutLog.findMany({
+      where,
+      orderBy: { checkedOutAt: 'asc' },
+      select: {
+        id: true,
+        checkedOutAt: true,
+        item: {
+          select: { id: true, name: true, condition: true },
+        },
+        user: {
+          select: { id: true, name: true },
+        },
+        checkedOutByUser: {
+          select: { id: true, name: true },
+        },
+        checkedOutFromLocation: {
+          select: { id: true, name: true },
+        },
+      },
+    }),
+    prisma.checkoutLog.count({ where }),
+  ])
+
+  const now = Date.now()
+
+  return {
+    checkouts: logs.map((log) => ({
+      id: log.id,
+      item: log.item,
+      user: log.user,
+      checkedOutBy: log.checkedOutByUser,
+      checkedOutFromLocation: log.checkedOutFromLocation,
+      checkedOutAt: log.checkedOutAt,
+      daysOut: Math.ceil((now - new Date(log.checkedOutAt).getTime()) / 86_400_000),
+    })),
+    total,
+  }
+})

--- a/server/api/dashboard.get.ts
+++ b/server/api/dashboard.get.ts
@@ -1,0 +1,67 @@
+export default defineEventHandler(async (event) => {
+  const session = event.context.session
+  const isAdminOrSupervisor = session.user.role === 'admin' || session.user.role === 'supervisor'
+
+  const [
+    totalItems,
+    checkedOutCount,
+    damagedCount,
+    totalLocations,
+    openCheckouts,
+    myOpenCheckouts,
+  ] = await Promise.all([
+    prisma.item.count({ where: { condition: { not: 'retired' } } }),
+    prisma.item.count({ where: { status: 'checked_out' } }),
+    prisma.item.count({ where: { condition: 'damaged' } }),
+    prisma.location.count({ where: { status: 'active' } }),
+    isAdminOrSupervisor
+      ? prisma.checkoutLog.findMany({
+          where: { checkedInAt: null },
+          orderBy: { checkedOutAt: 'asc' },
+          take: 5,
+          select: {
+            id: true,
+            checkedOutAt: true,
+            item: { select: { id: true, name: true } },
+            user: { select: { id: true, name: true } },
+            checkedOutFromLocation: { select: { id: true, name: true } },
+          },
+        })
+      : [],
+    prisma.checkoutLog.findMany({
+      where: { userId: session.user.id, checkedInAt: null },
+      orderBy: { checkedOutAt: 'desc' },
+      select: {
+        id: true,
+        checkedOutAt: true,
+        item: { select: { id: true, name: true } },
+        checkedOutFromLocation: { select: { id: true, name: true } },
+      },
+    }),
+  ])
+
+  const now = Date.now()
+
+  return {
+    stats: {
+      totalItems,
+      checkedOut: checkedOutCount,
+      damaged: damagedCount,
+      locations: totalLocations,
+    },
+    openCheckouts: openCheckouts.map((log) => ({
+      id: log.id,
+      item: log.item,
+      user: log.user,
+      checkedOutFromLocation: log.checkedOutFromLocation,
+      checkedOutAt: log.checkedOutAt,
+      daysOut: Math.ceil((now - new Date(log.checkedOutAt).getTime()) / 86_400_000),
+    })),
+    myItems: myOpenCheckouts.map((log) => ({
+      id: log.id,
+      item: log.item,
+      checkedOutFromLocation: log.checkedOutFromLocation,
+      checkedOutAt: log.checkedOutAt,
+    })),
+  }
+})

--- a/server/api/items/[id]/history.get.ts
+++ b/server/api/items/[id]/history.get.ts
@@ -1,0 +1,51 @@
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  const item = await prisma.item.findUnique({
+    where: { id },
+    select: { id: true },
+  })
+
+  if (!item) {
+    throw createError({ statusCode: 404, statusMessage: 'Item not found' })
+  }
+
+  const logs = await prisma.checkoutLog.findMany({
+    where: { itemId: id },
+    orderBy: { checkedOutAt: 'desc' },
+    select: {
+      id: true,
+      checkedOutAt: true,
+      checkedInAt: true,
+      conditionOnReturn: true,
+      user: {
+        select: { id: true, name: true },
+      },
+      checkedOutByUser: {
+        select: { id: true, name: true },
+      },
+      checkedOutFromLocation: {
+        select: { id: true, name: true },
+      },
+      checkedInByUser: {
+        select: { id: true, name: true },
+      },
+      checkedInAtLocation: {
+        select: { id: true, name: true },
+      },
+    },
+  })
+
+  return logs.map((log) => ({
+    id: log.id,
+    user: log.user,
+    checkedOutBy: log.checkedOutByUser,
+    checkedOutFromLocation: log.checkedOutFromLocation,
+    checkedOutAt: log.checkedOutAt,
+    checkedInBy: log.checkedInByUser,
+    checkedInAtLocation: log.checkedInAtLocation,
+    checkedInAt: log.checkedInAt,
+    conditionOnReturn: log.conditionOnReturn,
+    isOpen: log.checkedInAt === null,
+  }))
+})

--- a/server/api/users/[id]/history.get.ts
+++ b/server/api/users/[id]/history.get.ts
@@ -1,0 +1,57 @@
+export default defineEventHandler(async (event) => {
+  const session = event.context.session
+  const id = getRouterParam(event, 'id')
+
+  // Employees can only view their own history
+  if (session.user.role === 'employee' && session.user.id !== id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true },
+  })
+
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  const logs = await prisma.checkoutLog.findMany({
+    where: { userId: id },
+    orderBy: { checkedOutAt: 'desc' },
+    select: {
+      id: true,
+      checkedOutAt: true,
+      checkedInAt: true,
+      conditionOnReturn: true,
+      item: {
+        select: { id: true, name: true },
+      },
+      checkedOutByUser: {
+        select: { id: true, name: true },
+      },
+      checkedOutFromLocation: {
+        select: { id: true, name: true },
+      },
+      checkedInByUser: {
+        select: { id: true, name: true },
+      },
+      checkedInAtLocation: {
+        select: { id: true, name: true },
+      },
+    },
+  })
+
+  return logs.map((log) => ({
+    id: log.id,
+    item: log.item,
+    checkedOutBy: log.checkedOutByUser,
+    checkedOutFromLocation: log.checkedOutFromLocation,
+    checkedOutAt: log.checkedOutAt,
+    checkedInBy: log.checkedInByUser,
+    checkedInAtLocation: log.checkedInAtLocation,
+    checkedInAt: log.checkedInAt,
+    conditionOnReturn: log.conditionOnReturn,
+    isOpen: log.checkedInAt === null,
+  }))
+})

--- a/tests/api/checkouts.test.ts
+++ b/tests/api/checkouts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Response schema for GET /api/checkouts/open
+const openCheckoutEntrySchema = z.object({
+  id: z.string(),
+  item: z.object({ id: z.string(), name: z.string(), condition: z.string() }),
+  user: z.object({ id: z.string(), name: z.string() }),
+  checkedOutBy: z.object({ id: z.string(), name: z.string() }),
+  checkedOutFromLocation: z.object({ id: z.string(), name: z.string() }),
+  checkedOutAt: z.string(),
+  daysOut: z.number().int().min(0),
+})
+
+const openCheckoutsResponseSchema = z.object({
+  checkouts: z.array(openCheckoutEntrySchema),
+  total: z.number().int().min(0),
+})
+
+// Extracted logic: compute daysOut
+function computeDaysOut(checkedOutAt: string, now: number): number {
+  return Math.ceil((now - new Date(checkedOutAt).getTime()) / 86_400_000)
+}
+
+describe('open checkouts response shape', () => {
+  it('validates a response with checkouts', () => {
+    const response = {
+      checkouts: [
+        {
+          id: 'log-1',
+          item: { id: 'item-1', name: 'iPad Pro #3', condition: 'good' },
+          user: { id: 'user-1', name: 'Chris Abernathy' },
+          checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+          checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+          checkedOutAt: '2026-04-20T10:00:00.000Z',
+          daysOut: 5,
+        },
+      ],
+      total: 1,
+    }
+    const result = openCheckoutsResponseSchema.safeParse(response)
+    expect(result.success).toBe(true)
+  })
+
+  it('validates an empty response', () => {
+    const result = openCheckoutsResponseSchema.safeParse({ checkouts: [], total: 0 })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects negative daysOut', () => {
+    const entry = {
+      id: 'log-1',
+      item: { id: 'item-1', name: 'iPad', condition: 'good' },
+      user: { id: 'user-1', name: 'Test' },
+      checkedOutBy: { id: 'admin-1', name: 'Admin' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'Loc' },
+      checkedOutAt: '2026-04-20T10:00:00.000Z',
+      daysOut: -1,
+    }
+    const result = openCheckoutEntrySchema.safeParse(entry)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('daysOut computation', () => {
+  it('returns 1 for a checkout made less than 24 hours ago', () => {
+    const now = new Date('2026-04-25T10:00:00.000Z').getTime()
+    expect(computeDaysOut('2026-04-25T08:00:00.000Z', now)).toBe(1)
+  })
+
+  it('returns 1 for exactly 24 hours', () => {
+    const now = new Date('2026-04-26T10:00:00.000Z').getTime()
+    expect(computeDaysOut('2026-04-25T10:00:00.000Z', now)).toBe(1)
+  })
+
+  it('returns 5 for a checkout made 5 days ago', () => {
+    const now = new Date('2026-04-25T10:00:00.000Z').getTime()
+    expect(computeDaysOut('2026-04-20T10:00:00.000Z', now)).toBe(5)
+  })
+
+  it('returns 31 for a checkout made 31 days ago', () => {
+    const now = new Date('2026-04-25T10:00:00.000Z').getTime()
+    expect(computeDaysOut('2026-03-25T10:00:00.000Z', now)).toBe(31)
+  })
+})

--- a/tests/api/item-history.test.ts
+++ b/tests/api/item-history.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Response schema matching the shape returned by GET /api/items/[id]/history
+const historyEntrySchema = z.object({
+  id: z.string(),
+  user: z.object({ id: z.string(), name: z.string() }),
+  checkedOutBy: z.object({ id: z.string(), name: z.string() }),
+  checkedOutFromLocation: z.object({ id: z.string(), name: z.string() }),
+  checkedOutAt: z.string(),
+  checkedInBy: z.object({ id: z.string(), name: z.string() }).nullable(),
+  checkedInAtLocation: z.object({ id: z.string(), name: z.string() }).nullable(),
+  checkedInAt: z.string().nullable(),
+  conditionOnReturn: z.string().nullable(),
+  isOpen: z.boolean(),
+})
+
+const historyResponseSchema = z.array(historyEntrySchema)
+
+// Extracted logic: compute isOpen from a log entry
+function computeIsOpen(checkedInAt: string | null): boolean {
+  return checkedInAt === null
+}
+
+describe('item history response shape', () => {
+  it('validates a complete closed checkout entry', () => {
+    const entry = {
+      id: 'log-1',
+      user: { id: 'user-1', name: 'Chris Abernathy' },
+      checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+      checkedOutAt: '2026-04-20T10:00:00.000Z',
+      checkedInBy: { id: 'admin-2', name: 'Isabel Saenz' },
+      checkedInAtLocation: { id: 'loc-2', name: 'TWC - East' },
+      checkedInAt: '2026-04-24T14:00:00.000Z',
+      conditionOnReturn: 'good',
+      isOpen: false,
+    }
+    const result = historyResponseSchema.safeParse([entry])
+    expect(result.success).toBe(true)
+  })
+
+  it('validates an open checkout entry with null check-in fields', () => {
+    const entry = {
+      id: 'log-2',
+      user: { id: 'user-2', name: 'Dana Dodgen' },
+      checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+      checkedOutAt: '2026-04-25T09:00:00.000Z',
+      checkedInBy: null,
+      checkedInAtLocation: null,
+      checkedInAt: null,
+      conditionOnReturn: null,
+      isOpen: true,
+    }
+    const result = historyResponseSchema.safeParse([entry])
+    expect(result.success).toBe(true)
+  })
+
+  it('validates empty history array', () => {
+    const result = historyResponseSchema.safeParse([])
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects entry missing required fields', () => {
+    const result = historyEntrySchema.safeParse({ id: 'log-1' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('isOpen computation', () => {
+  it('returns true when checkedInAt is null', () => {
+    expect(computeIsOpen(null)).toBe(true)
+  })
+
+  it('returns false when checkedInAt has a value', () => {
+    expect(computeIsOpen('2026-04-24T14:00:00.000Z')).toBe(false)
+  })
+})

--- a/tests/api/user-history.test.ts
+++ b/tests/api/user-history.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Response schema matching the shape returned by GET /api/users/[id]/history
+const userHistoryEntrySchema = z.object({
+  id: z.string(),
+  item: z.object({ id: z.string(), name: z.string() }),
+  checkedOutBy: z.object({ id: z.string(), name: z.string() }),
+  checkedOutFromLocation: z.object({ id: z.string(), name: z.string() }),
+  checkedOutAt: z.string(),
+  checkedInBy: z.object({ id: z.string(), name: z.string() }).nullable(),
+  checkedInAtLocation: z.object({ id: z.string(), name: z.string() }).nullable(),
+  checkedInAt: z.string().nullable(),
+  conditionOnReturn: z.string().nullable(),
+  isOpen: z.boolean(),
+})
+
+const userHistoryResponseSchema = z.array(userHistoryEntrySchema)
+
+describe('user history response shape', () => {
+  it('validates a complete closed checkout entry', () => {
+    const entry = {
+      id: 'log-1',
+      item: { id: 'item-1', name: 'iPad Pro #3' },
+      checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+      checkedOutAt: '2026-04-20T10:00:00.000Z',
+      checkedInBy: { id: 'admin-2', name: 'Isabel Saenz' },
+      checkedInAtLocation: { id: 'loc-2', name: 'TWC - East' },
+      checkedInAt: '2026-04-24T14:00:00.000Z',
+      conditionOnReturn: 'good',
+      isOpen: false,
+    }
+    const result = userHistoryResponseSchema.safeParse([entry])
+    expect(result.success).toBe(true)
+  })
+
+  it('validates an open checkout entry', () => {
+    const entry = {
+      id: 'log-2',
+      item: { id: 'item-2', name: 'Therapy Ball' },
+      checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+      checkedOutAt: '2026-04-25T09:00:00.000Z',
+      checkedInBy: null,
+      checkedInAtLocation: null,
+      checkedInAt: null,
+      conditionOnReturn: null,
+      isOpen: true,
+    }
+    const result = userHistoryResponseSchema.safeParse([entry])
+    expect(result.success).toBe(true)
+  })
+
+  it('validates empty history array', () => {
+    const result = userHistoryResponseSchema.safeParse([])
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects entry with item field instead having user field shape', () => {
+    const badEntry = {
+      id: 'log-1',
+      user: { id: 'user-1', name: 'Someone' },
+      checkedOutBy: { id: 'admin-1', name: 'Brandy Lindsey' },
+      checkedOutFromLocation: { id: 'loc-1', name: 'TWC - Central' },
+      checkedOutAt: '2026-04-20T10:00:00.000Z',
+      checkedInBy: null,
+      checkedInAtLocation: null,
+      checkedInAt: null,
+      conditionOnReturn: null,
+      isOpen: true,
+    }
+    const result = userHistoryEntrySchema.safeParse(badEntry)
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add 3 API endpoints: item history, user history, open checkouts dashboard
- Expand item detail page with lazy-loaded full history and "View all" button
- Split user detail page history into "Currently Holding" and "Past Checkouts" sections
- Add checkout history to profile page for all users
- New `/checkouts` dashboard page for admin/supervisor with location filters and days-out badges
- Add "Checkouts" navigation link for admin/supervisor roles

## API Endpoints

| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| `GET` | `/api/items/[id]/history` | All | Full checkout history for an item |
| `GET` | `/api/users/[id]/history` | Admin/Supervisor or own | Full checkout history for a user |
| `GET` | `/api/checkouts/open` | Admin/Supervisor | All currently checked-out items |

## Test plan

- [x] All 105 tests pass (`pnpm test`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Lint passes with no errors (`pnpm lint`)
- [ ] Item detail page shows history with "View all" when 10+ records
- [ ] User detail page splits into "Currently Holding" / "Past Checkouts"
- [ ] Profile page shows user's own checkout history
- [ ] `/checkouts` dashboard shows open checkouts with filters and days-out badges
- [ ] Non-admin/supervisor redirected away from `/checkouts`
- [ ] Employees can only see their own history (403 for others)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)