### PR TITLE
Add QR scan landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
 - **Header**: `UHeader` component with `UNavigationMenu` — responsive hamburger menu on mobile (<lg), horizontal nav on desktop
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard with live stats and recent activity), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard with live stats and recent activity), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/items/scan` (QR code landing page — redirects `?id=` to item detail), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
 
 ### Backend (`server/`)
 
@@ -34,6 +34,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Role utility**: `server/utils/require-role.ts` — `requireRole(event, 'admin')` one-liner for role checks in route handlers
 - **Prisma client**: `server/utils/prisma.ts` — uses `@prisma/adapter-better-sqlite3` driver adapter
 - **Display name utility**: `server/utils/display-name.ts` — computes display name from preferred/legal name fields
+- **QR code utility**: `server/utils/qr.ts` — generates QR code PNGs encoding `/items/scan?id=<uuid>` URLs
 - **API routes**: `server/api/dashboard.get.ts` (aggregated stats and recent activity), `server/api/users/` (user CRUD, profile pictures, `/me` endpoint, `GET /api/users/[id]/history` for checkout history), `server/api/locations/` (location CRUD with soft delete), `server/api/items/` (item CRUD, `POST /api/items/[id]/checkout` for check-out flow, `POST /api/items/[id]/checkin` for check-in flow, `GET /api/items/[id]/history` for checkout history), `server/api/checkouts/` (`GET /api/checkouts/open` for open checkouts dashboard)
 - **No hard deletes**: All entities use soft delete — locations set `status: 'inactive'`, users set `status: 'inactive'`, items set `condition: 'retired'`. This preserves checkout history.
 

--- a/app/pages/items/scan.vue
+++ b/app/pages/items/scan.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+  const route = useRoute()
+
+  useHead({ title: 'Loading item...' })
+
+  const id = route.query.id as string | undefined
+
+  if (id) {
+    await navigateTo(`/items/${id}`, { replace: true })
+  }
+</script>
+
+<template>
+  <UContainer v-if="!id" class="py-8">
+    <UCard>
+      <div class="flex flex-col items-center gap-4 py-8 text-center">
+        <UIcon name="i-lucide-scan-line" class="text-red-500" size="48" />
+        <h1 class="text-xl font-semibold">Invalid QR Code</h1>
+        <p class="text-gray-500">No item ID provided. This QR code may be invalid.</p>
+        <UButton to="/items" variant="soft"> Browse Items </UButton>
+      </div>
+    </UCard>
+  </UContainer>
+</template>

--- a/docs/features/items.md
+++ b/docs/features/items.md
@@ -47,7 +47,7 @@ Displays:
 - Home location and current location
 - QR code (with print button)
 - Checkout history (recent 10 from CheckoutLog, with "View all history" button for lazy-loaded full history)
-- If admin: edit/delete buttons
+- If admin: edit button, retire/reactivate button
 - If admin/supervisor and item is available: "Check Out" button
 - If admin/supervisor and item is checked out: "Check In" button with current holder info
 

--- a/docs/features/locations.md
+++ b/docs/features/locations.md
@@ -16,12 +16,12 @@ Fields:
 
 ## Permissions
 
-| Action          | Admin | Supervisor | Employee |
-| --------------- | ----- | ---------- | -------- |
-| View locations  | Yes   | Yes        | Yes      |
-| Create location | Yes   | No         | No       |
-| Edit location   | Yes   | No         | No       |
-| Delete location | Yes   | No         | No       |
+| Action              | Admin | Supervisor | Employee |
+| ------------------- | ----- | ---------- | -------- |
+| View locations      | Yes   | Yes        | Yes      |
+| Create location     | Yes   | No         | No       |
+| Edit location       | Yes   | No         | No       |
+| Deactivate location | Yes   | No         | No       |
 
 ## Seed Locations
 
@@ -40,7 +40,7 @@ Three locations are seeded at setup:
 **Route**: `/locations`
 
 - Table/list of all locations with name and address
-- Admin sees "Add Location" button and edit/delete actions per row
+- Admin sees "Add Location" button and edit/deactivate actions per row
 - Each location links to its detail page
 
 ### Location Detail Page
@@ -53,7 +53,7 @@ Displays:
 - Count of items with this as home location
 - Count of items currently at this location
 - List of items currently at this location (links to item detail)
-- Admin: edit/delete buttons
+- Admin: edit/deactivate buttons
 
 ### Create / Edit Form
 


### PR DESCRIPTION
Closes #11

## Summary
- Add `/items/scan` page that reads `?id=` query param and redirects to `/items/:id`
- Shows error UI with link to items list when no ID is provided
- Uses `replace: true` so the scan URL doesn't pollute browser history
- Works with existing auth middleware redirect-after-login flow (query params preserved)

## Test plan
- [ ] Visit `/items/scan?id=<valid-uuid>` while logged in → redirects to item detail
- [ ] Visit `/items/scan` (no id) → shows "Invalid QR Code" error with link to browse items
- [ ] Visit `/items/scan?id=<uuid>` while logged out → login flow → lands on item detail
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (no new warnings)
- [ ] All 105 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)