### PR TITLE
QR code print views: single item and batch printing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Nuxt 4 template app with Better Auth (email OTP authentication), Prisma ORM, SQL
 - **Auth client**: `app/utils/auth-client.ts` — Better Auth Vue client with emailOTP plugin
 - **Global auth middleware**: `app/middleware/auth.global.ts` — redirects unauthenticated users to `/auth`, authenticated users away from `/auth`
 - **Header**: `UHeader` component with `UNavigationMenu` — responsive hamburger menu on mobile (<lg), horizontal nav on desktop
-- **Pages**: `/auth` (email OTP login flow), `/` (dashboard with live stats and recent activity), `/items` (item list), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/items/scan` (QR code landing page — redirects `?id=` to item detail), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
+- **Pages**: `/auth` (email OTP login flow), `/` (dashboard with live stats and recent activity), `/items` (item list with batch-select print mode), `/items/[id]` (item detail with check-out/check-in modals and full checkout history), `/items/print-[id]` (single-item QR label print view with size selector), `/items/print` (batch QR label print view for multiple items), `/items/scan` (QR code landing page — redirects `?id=` to item detail), `/locations` (location list), `/locations/[id]` (location detail), `/users` (user list, admin/supervisor), `/users/[id]` (user detail with checkout history), `/checkouts` (open checkouts dashboard, admin/supervisor), `/profile` (self-service profile with checkout history)
 
 ### Backend (`server/`)
 

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,2 +1,28 @@
 @import 'tailwindcss';
 @import '@nuxt/ui';
+
+@media print {
+  .print-controls,
+  header,
+  nav {
+    display: none !important;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .print-page {
+    margin: 0;
+    padding: 0;
+  }
+
+  .print-label {
+    break-inside: avoid;
+  }
+
+  .print-page-break {
+    break-after: page;
+  }
+}

--- a/app/components/PrintLabel.vue
+++ b/app/components/PrintLabel.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+  import type { LabelSize } from '~/composables/usePrintLabels'
+  import { labelSizes } from '~/composables/usePrintLabels'
+
+  const props = defineProps<{
+    itemId: string
+    itemName: string
+    size: LabelSize
+  }>()
+
+  const emit = defineEmits<{ loaded: [] }>()
+
+  const config = computed(() => labelSizes[props.size])
+  const shortId = computed(() => props.itemId.slice(0, 8))
+</script>
+
+<template>
+  <div
+    class="print-label flex flex-col items-center justify-center"
+    :style="{
+      width: config.inches + 'in',
+      height: config.inches + 'in',
+    }"
+  >
+    <!-- eslint-disable-next-line vue/html-self-closing -->
+    <img
+      :src="`/api/items/${itemId}/qr?size=${config.qrPx}`"
+      alt="QR Code"
+      class="max-h-[70%] max-w-[80%]"
+      @load="emit('loaded')"
+    />
+    <p
+      class="mt-0.5 max-w-[90%] truncate text-center"
+      :style="{ fontSize: config.inches <= 1 ? '6pt' : '8pt' }"
+    >
+      {{ itemName }}
+    </p>
+    <p class="font-mono text-[#666]" :style="{ fontSize: config.inches <= 1 ? '5pt' : '6pt' }">
+      {{ shortId }}
+    </p>
+  </div>
+</template>

--- a/app/composables/usePrintLabels.ts
+++ b/app/composables/usePrintLabels.ts
@@ -1,0 +1,25 @@
+export type LabelSize = 'small' | 'medium' | 'large'
+
+export interface LabelSizeConfig {
+  label: string
+  inches: number
+  qrPx: number
+  cols: number
+  rows: number
+  perPage: number
+}
+
+export const labelSizes: Record<LabelSize, LabelSizeConfig> = {
+  small: { label: 'Small (1")', inches: 1, qrPx: 100, cols: 7, rows: 10, perPage: 70 },
+  medium: { label: 'Medium (2")', inches: 2, qrPx: 200, cols: 4, rows: 5, perPage: 20 },
+  large: { label: 'Large (3")', inches: 3, qrPx: 300, cols: 2, rows: 3, perPage: 6 },
+}
+
+export const labelSizeOptions = Object.entries(labelSizes).map(([value, config]) => ({
+  label: config.label,
+  value,
+}))
+
+export function pageCount(itemCount: number, size: LabelSize): number {
+  return Math.ceil(itemCount / labelSizes[size].perPage)
+}

--- a/app/pages/items/[id].vue
+++ b/app/pages/items/[id].vue
@@ -375,6 +375,14 @@
                 <UButton
                   variant="soft"
                   color="neutral"
+                  icon="i-heroicons-printer-20-solid"
+                  label="Print QR"
+                  size="sm"
+                  :to="`/items/print-${id}?size=medium`"
+                />
+                <UButton
+                  variant="soft"
+                  color="neutral"
                   icon="i-heroicons-pencil-square-20-solid"
                   label="Edit"
                   size="sm"

--- a/app/pages/items/index.vue
+++ b/app/pages/items/index.vue
@@ -1,11 +1,51 @@
 <script setup lang="ts">
   import { z } from 'zod'
   import type { FormSubmitEvent } from '@nuxt/ui'
+  import type { LabelSize } from '~/composables/usePrintLabels'
+  import { labelSizeOptions } from '~/composables/usePrintLabels'
 
   const toast = useToast()
 
   const { data: session } = await authClient.useSession(useFetch)
   const isAdmin = computed(() => session.value?.user?.role === 'admin')
+
+  // Selection mode for batch printing
+  const isSelectMode = ref(false)
+  const selectedIds = ref(new Set<string>())
+  const printSize = ref<LabelSize>('medium')
+
+  const allSelected = computed(() => {
+    if (!items.value?.length) return false
+    return items.value.every((item) => selectedIds.value.has(item.id))
+  })
+
+  function toggleSelectMode() {
+    isSelectMode.value = !isSelectMode.value
+    selectedIds.value.clear()
+  }
+
+  function toggleSelectAll() {
+    if (allSelected.value) {
+      selectedIds.value.clear()
+    } else if (items.value) {
+      for (const item of items.value) {
+        selectedIds.value.add(item.id)
+      }
+    }
+  }
+
+  function toggleItem(id: string) {
+    if (selectedIds.value.has(id)) {
+      selectedIds.value.delete(id)
+    } else {
+      selectedIds.value.add(id)
+    }
+  }
+
+  function openBatchPrint() {
+    const ids = [...selectedIds.value].join(',')
+    navigateTo(`/items/print?ids=${ids}&size=${printSize.value}`)
+  }
 
   // Filters
   const statusFilter = ref<string>('all')
@@ -184,6 +224,13 @@
       </div>
       <div v-if="isAdmin" class="flex items-center gap-3">
         <UButton
+          variant="soft"
+          :color="isSelectMode ? 'primary' : 'neutral'"
+          icon="i-heroicons-printer-20-solid"
+          :label="isSelectMode ? 'Cancel' : 'Print Labels'"
+          @click="toggleSelectMode"
+        />
+        <UButton
           color="primary"
           icon="i-heroicons-plus-20-solid"
           label="Add Item"
@@ -225,6 +272,37 @@
       </UButtonGroup>
     </div>
 
+    <!-- Selection toolbar -->
+    <div
+      v-if="isSelectMode"
+      class="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800"
+    >
+      <label class="flex cursor-pointer items-center gap-2 text-sm">
+        <!-- eslint-disable-next-line vue/html-self-closing -->
+        <input type="checkbox" :checked="allSelected" class="rounded" @change="toggleSelectAll" />
+        Select all
+      </label>
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ selectedIds.size }} selected
+      </span>
+      <select
+        v-model="printSize"
+        class="rounded-md border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700"
+      >
+        <option v-for="opt in labelSizeOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+      <UButton
+        color="primary"
+        icon="i-heroicons-printer-20-solid"
+        label="Print Selected"
+        size="sm"
+        :disabled="!selectedIds.size"
+        @click="openBatchPrint"
+      />
+    </div>
+
     <!-- Loading -->
     <UCard v-if="pending">
       <div class="space-y-4">
@@ -254,44 +332,56 @@
 
     <!-- Item list -->
     <div v-else class="space-y-3">
-      <NuxtLink v-for="item in items" :key="item.id" :to="`/items/${item.id}`" class="block">
-        <UCard
-          class="transition-shadow hover:shadow-md"
-          :class="{ 'opacity-60': item.condition === 'retired' }"
-        >
-          <div class="flex items-center justify-between">
-            <div class="min-w-0 flex-1">
-              <div class="flex items-center gap-2">
-                <p class="truncate font-medium text-gray-900 dark:text-white">{{ item.name }}</p>
-                <UBadge :color="conditionBadgeColor(item.condition)" variant="subtle" size="sm">
-                  {{ item.condition }}
-                </UBadge>
-                <UBadge :color="statusBadgeColor(item.status)" variant="subtle" size="sm">
-                  {{ statusLabel(item.status) }}
-                </UBadge>
+      <div v-for="item in items" :key="item.id" class="flex items-center gap-3">
+        <!-- eslint-disable-next-line vue/html-self-closing -->
+        <input
+          v-if="isSelectMode"
+          type="checkbox"
+          :checked="selectedIds.has(item.id)"
+          class="shrink-0 rounded"
+          @change="toggleItem(item.id)"
+        />
+        <NuxtLink :to="`/items/${item.id}`" class="block min-w-0 flex-1">
+          <UCard
+            class="transition-shadow hover:shadow-md"
+            :class="{ 'opacity-60': item.condition === 'retired' }"
+          >
+            <div class="flex items-center justify-between">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2">
+                  <p class="truncate font-medium text-gray-900 dark:text-white">
+                    {{ item.name }}
+                  </p>
+                  <UBadge :color="conditionBadgeColor(item.condition)" variant="subtle" size="sm">
+                    {{ item.condition }}
+                  </UBadge>
+                  <UBadge :color="statusBadgeColor(item.status)" variant="subtle" size="sm">
+                    {{ statusLabel(item.status) }}
+                  </UBadge>
+                </div>
+                <p
+                  v-if="item.description"
+                  class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400"
+                >
+                  {{ item.description }}
+                </p>
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  {{ item.currentLocation.name }}
+                </p>
               </div>
-              <p
-                v-if="item.description"
-                class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400"
-              >
-                {{ item.description }}
-              </p>
-              <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-                {{ item.currentLocation.name }}
-              </p>
+              <div v-if="isAdmin && !isSelectMode" class="ml-4 flex shrink-0 items-center gap-2">
+                <UButton
+                  variant="ghost"
+                  color="neutral"
+                  icon="i-heroicons-pencil-square-20-solid"
+                  size="sm"
+                  @click.prevent="openEdit(item)"
+                />
+              </div>
             </div>
-            <div v-if="isAdmin" class="ml-4 flex shrink-0 items-center gap-2">
-              <UButton
-                variant="ghost"
-                color="neutral"
-                icon="i-heroicons-pencil-square-20-solid"
-                size="sm"
-                @click.prevent="openEdit(item)"
-              />
-            </div>
-          </div>
-        </UCard>
-      </NuxtLink>
+          </UCard>
+        </NuxtLink>
+      </div>
     </div>
 
     <!-- Create/Edit Modal -->

--- a/app/pages/items/print-[id].vue
+++ b/app/pages/items/print-[id].vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+  import type { LabelSize } from '~/composables/usePrintLabels'
+  import { labelSizes, labelSizeOptions } from '~/composables/usePrintLabels'
+
+  definePageMeta({ layout: false })
+
+  const route = useRoute()
+  const id = route.params.id as string
+
+  const sizeParam = (route.query.size as string) || 'medium'
+  const selectedSize = ref<LabelSize>(sizeParam in labelSizes ? (sizeParam as LabelSize) : 'medium')
+
+  const { data: item, error } = await useFetch<{ name: string }>(`/api/items/${id}`, {
+    pick: ['name'],
+  })
+
+  function triggerPrint() {
+    window.print()
+  }
+
+  onMounted(() => {
+    nextTick(() => {
+      triggerPrint()
+    })
+  })
+</script>
+
+<template>
+  <div>
+    <!-- Screen controls -->
+    <div class="print-controls mx-auto max-w-md px-4 py-8">
+      <NuxtLink
+        :to="`/items/${id}`"
+        class="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        &larr; Back to item
+      </NuxtLink>
+
+      <h1 class="mb-4 text-xl font-bold text-gray-900 dark:text-white">Print QR Label</h1>
+
+      <div v-if="error" class="mb-4 text-red-600">Item not found.</div>
+
+      <template v-else-if="item">
+        <div class="mb-4">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Label Size
+          </label>
+          <select
+            v-model="selectedSize"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800"
+          >
+            <option v-for="opt in labelSizeOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
+
+        <p class="mb-4 text-sm text-gray-500">
+          Preview at actual size ({{ labelSizes[selectedSize].inches }}" &times;
+          {{ labelSizes[selectedSize].inches }}"):
+        </p>
+
+        <!-- Label preview -->
+        <div class="mb-6 inline-block border border-dashed border-gray-300 dark:border-gray-600">
+          <PrintLabel :item-id="id" :item-name="item.name" :size="selectedSize" />
+        </div>
+
+        <div>
+          <button
+            class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+            @click="triggerPrint"
+          >
+            Print
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- Print output -->
+    <div class="print-page hidden print:block">
+      <PrintLabel v-if="item" :item-id="id" :item-name="item.name" :size="selectedSize" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  @media print {
+    @page {
+      margin: 0;
+    }
+  }
+</style>

--- a/app/pages/items/print.vue
+++ b/app/pages/items/print.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+  import type { LabelSize } from '~/composables/usePrintLabels'
+  import { labelSizes, labelSizeOptions, pageCount } from '~/composables/usePrintLabels'
+
+  definePageMeta({ layout: false })
+
+  const route = useRoute()
+
+  const idsParam = (route.query.ids as string) || ''
+  const selectedIds = idsParam.split(',').filter(Boolean)
+
+  const sizeParam = (route.query.size as string) || 'medium'
+  const selectedSize = ref<LabelSize>(sizeParam in labelSizes ? (sizeParam as LabelSize) : 'medium')
+
+  const config = computed(() => labelSizes[selectedSize.value])
+  const pages = computed(() => pageCount(selectedIds.length, selectedSize.value))
+
+  // Fetch all items and filter to selected IDs
+  const { data: allItems } = await useFetch<{ id: string; name: string }[]>('/api/items')
+
+  const items = computed(() => {
+    if (!allItems.value) return []
+    const idSet = new Set(selectedIds)
+    return allItems.value.filter((item) => idSet.has(item.id))
+  })
+
+  // Track image loading for auto-print
+  const loadedCount = ref(0)
+  const allLoaded = computed(() => loadedCount.value >= items.value.length)
+
+  function onImageLoad() {
+    loadedCount.value++
+  }
+
+  function triggerPrint() {
+    window.print()
+  }
+
+  // Auto-print once all images loaded
+  watch(allLoaded, (loaded) => {
+    if (loaded && items.value.length > 0) {
+      nextTick(() => {
+        triggerPrint()
+      })
+    }
+  })
+
+  // Group items into pages
+  const pagedItems = computed(() => {
+    const perPage = config.value.perPage
+    const result: { id: string; name: string }[][] = []
+    for (let i = 0; i < items.value.length; i += perPage) {
+      result.push(items.value.slice(i, i + perPage))
+    }
+    return result
+  })
+</script>
+
+<template>
+  <div>
+    <!-- Screen controls -->
+    <div class="print-controls mx-auto max-w-2xl px-4 py-8">
+      <NuxtLink
+        to="/items"
+        class="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        &larr; Back to items
+      </NuxtLink>
+
+      <h1 class="mb-4 text-xl font-bold text-gray-900 dark:text-white">Batch Print Labels</h1>
+
+      <div v-if="!selectedIds.length" class="text-red-600">No items selected.</div>
+
+      <template v-else>
+        <div class="mb-4 flex flex-wrap items-center gap-4">
+          <div>
+            <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Label Size
+            </label>
+            <select
+              v-model="selectedSize"
+              class="rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800"
+            >
+              <option v-for="opt in labelSizeOptions" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </select>
+          </div>
+          <div class="text-sm text-gray-600 dark:text-gray-400">
+            {{ items.length }} labels &middot; {{ pages }}
+            {{ pages === 1 ? 'page' : 'pages' }}
+          </div>
+          <button
+            class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+            :disabled="!allLoaded"
+            @click="triggerPrint"
+          >
+            {{ allLoaded ? 'Print' : 'Loading...' }}
+          </button>
+        </div>
+
+        <!-- Screen preview -->
+        <p class="mb-3 text-sm text-gray-500">
+          Preview ({{ config.cols }} &times; {{ config.rows }} per page):
+        </p>
+        <div class="overflow-auto border border-dashed border-gray-300 p-2 dark:border-gray-600">
+          <div
+            class="grid gap-0"
+            :style="{
+              gridTemplateColumns: `repeat(${config.cols}, ${config.inches}in)`,
+            }"
+          >
+            <div v-for="item in items" :key="item.id" class="border border-dotted border-gray-200">
+              <PrintLabel :item-id="item.id" :item-name="item.name" :size="selectedSize" />
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- Print output -->
+    <div class="print-page hidden print:block">
+      <div
+        v-for="(page, pageIndex) in pagedItems"
+        :key="pageIndex"
+        :class="{ 'print-page-break': pageIndex < pagedItems.length - 1 }"
+      >
+        <div
+          class="grid gap-0"
+          :style="{
+            gridTemplateColumns: `repeat(${config.cols}, ${config.inches}in)`,
+            gridAutoRows: config.inches + 'in',
+          }"
+        >
+          <PrintLabel
+            v-for="item in page"
+            :key="item.id"
+            :item-id="item.id"
+            :item-name="item.name"
+            :size="selectedSize"
+            @loaded="onImageLoad"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  @media print {
+    @page {
+      size: letter;
+      margin: 0.25in;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add single-item print page (`/items/print-[id]`) with size selector (1"/2"/3") and auto-print on load
- Add batch print page (`/items/print`) with grid layout matching label sheet dimensions (70/20/6 labels per page)
- Add selection mode to items list page with checkboxes, select all, and "Print Labels" button (admin only)
- Shared `PrintLabel` component and `usePrintLabels` composable for label size config
- Print CSS hides app chrome and handles page breaks

## Test plan
- [ ] Go to `/items/:id` → "Print QR" button visible for admins → click opens print preview
- [ ] Size selector changes label dimensions (1", 2", 3")
- [ ] `window.print()` produces clean label with QR code, item name, short ID
- [ ] Items list → "Print Labels" toggle → checkboxes appear → select items → "Print Selected" opens batch view
- [ ] Batch view shows correct grid layout and page count for each size
- [ ] Page breaks work correctly for multi-page batches
- [ ] All 3 sizes produce correctly dimensioned output when printed

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)